### PR TITLE
doc to tiff stream sample fix

### DIFF
--- a/samples/python/ConvertDocumentToTIFFStream.py
+++ b/samples/python/ConvertDocumentToTIFFStream.py
@@ -68,7 +68,8 @@ def ProcessFile(filename, outFilename, console, options = ""):
 					pageIndex += 1
 
 		memBuffer.seek(0)
-		shutil.copyfileobj(memBuffer, outFilename)
+		with open(outFilename, 'wb') as outFile:
+            shutil.copyfileobj(memBuffer, outFile)
 
 		
 try:


### PR DESCRIPTION
The previous version caused an error for me in Python 3.10