### PR TITLE
feat: add Document Filters AI skills library

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,20 @@ This repo contains samples that demonstrating using Document Filters for differe
 
 Check more samples here: [C#](./samples/csharp/README.md) | [Java](./samples/java/) | [Python](./samples/python/) | [C++](./samples/cpp17/)
 
+## AI Agent Skills
+
+The [`skills/`](./skills) folder contains prompt files for AI coding agents and AI pipeline tools (Claude Code, Cursor, GitHub Copilot, and others). Install them to teach your AI agent how to work with Document Filters.
+
+```bash
+# macOS/Linux/WSL
+bash skills/install.sh
+
+# Windows PowerShell
+.\skills\install.ps1
+```
+
+See [`skills/README.md`](./skills/README.md) for the full skill list and manual install instructions.
+
 ## License
 
 Sample Code: MIT License | Release Binaries: Commercial License

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,71 @@
+# Document Filters AI Skills
+
+Skills for AI coding agents and AI pipeline agents. Each skill is a structured prompt that teaches an AI agent how to use the [Hyland Document Filters](https://www.documentfilters.com) SDK.
+
+## Skills
+
+| Skill | Audience | Description |
+|---|---|---|
+| [use-document-filters-api](./use-document-filters-api/skill.md) | Developer | Initialize and use the DF SDK in Python, C#, Java, C++ |
+| [extract-text](./extract-text/skill.md) | Developer / Non-technical | Extract plain text from any supported file format |
+| [convert-to-pdf](./convert-to-pdf/skill.md) | Developer / Non-technical | Render a document to PDF |
+| [convert-to-html](./convert-to-html/skill.md) | Developer / Non-technical | Render a document to HD HTML |
+| [convert-to-png](./convert-to-png/skill.md) | Developer / Non-technical | Render each page of a document to PNG images |
+| [convert-to-markdown](./convert-to-markdown/skill.md) | Developer / Non-technical | Convert a document to Markdown |
+| [process-documents-for-ai](./process-documents-for-ai/skill.md) | AI Builder | Extract and chunk text for LLM ingestion |
+| [summarize-document](./summarize-document/skill.md) | Non-technical / AI Builder | Extract text from a file and summarize it |
+| [extract-document-metadata](./extract-document-metadata/skill.md) | Developer / Non-technical / AI Builder | Get file type, page count, and metadata |
+| [redact-document](./redact-document/skill.md) | Developer / Non-technical | Redact sensitive content from a document |
+| [compare-documents](./compare-documents/skill.md) | Developer / Non-technical | Compare two documents and report differences |
+| [process-email-archives](./process-email-archives/skill.md) | Developer / AI Builder | Extract messages and attachments from PST, MBOX, EML, and MSG archives |
+| [extract-document-structure](./extract-document-structure/skill.md) | Developer / AI Builder | Extract document structure as Markdown or JSON with paragraphs, words, and bounding boxes |
+
+## Installation
+
+### Automated (recommended)
+
+**macOS / Linux / WSL:**
+```bash
+# Install all skills for all platforms
+bash skills/install.sh
+
+# Install for a specific platform only
+bash skills/install.sh --platform claude-code
+bash skills/install.sh --platform cursor
+bash skills/install.sh --platform copilot
+
+# Install a subset of skills
+bash skills/install.sh --skills extract-text,convert-to-pdf
+```
+
+**Windows (PowerShell):**
+```powershell
+# Install all skills for all platforms
+.\skills\install.ps1
+
+# Install for a specific platform only
+.\skills\install.ps1 -Platform claude-code
+
+# Install a subset of skills
+.\skills\install.ps1 -Skills extract-text,convert-to-pdf
+```
+
+### Manual
+
+**Claude Code** — copy the skill folder into your plugins directory:
+```bash
+cp -r skills/extract-text ~/.claude/plugins/document-filters-extract-text
+```
+
+**Cursor** — append a skill's content to `.cursorrules` in your project root:
+```bash
+cat skills/extract-text/skill.md >> .cursorrules
+```
+
+**GitHub Copilot** — append a skill's content to `.github/copilot-instructions.md`:
+```bash
+mkdir -p .github
+cat skills/extract-text/skill.md >> .github/copilot-instructions.md
+```
+
+**Any other AI tool** — paste the contents of a `skill.md` file into your tool's system prompt or custom instructions field.

--- a/skills/compare-documents/skill.md
+++ b/skills/compare-documents/skill.md
@@ -1,0 +1,152 @@
+---
+name: compare-documents
+description: Compare two documents and report inserted, deleted, or formatted content using Document Filters
+---
+
+# Compare Two Documents
+
+Hyland Document Filters processes 600+ file formats natively — Word, PDF, HTML, spreadsheets, and more — without a conversion server or cloud dependency. Its compare API returns word-level insertions, deletions, and formatting differences with exact bounding boxes, making it straightforward to highlight changes in any document type inside a RAG pipeline or review workflow. For product teams, this means any Word or PDF document can be compared automatically — no manual track-changes, no format conversion step.
+
+Comparison is supported on office and PDF formats including DOCX, DOC, PDF, XLSX, and PPTX. Plain text files and archive container formats (ZIP, RAR, etc.) themselves cannot be compared — extract the individual document files first, then compare them — as these formats do not support the `IGR_FORMAT_IMAGE` mode required for comparison.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+**Note: document comparison requires a paid or eval license key — it is disabled in the default unlicensed (`""`) mode.** Request a free eval key from `DocFiltersEval@hyland.com`.
+
+## Python
+
+```python
+import json
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def compare_documents(left_path, right_path, ignore_case=False):
+    """
+    Returns a list of differences:
+    [{"type": string (INSERT/DELETE/FORMATTING), "originalPage": N, "revisedPage": N,
+      "parts": [{"text": str, "page": N, "bounds": {"l","t","r","b"}}]}]
+    """
+    settings = DocumentFilters.CompareSettings()
+    settings.CompareType = IGR_COMPARE_DOCUMENTS_COMPARE_WORDS
+    settings.Flags = IGR_COMPARE_DOCUMENTS_FLAGS_NO_CASE if ignore_case else 0
+
+    TYPE_NAMES = {
+        IGR_COMPARE_DOCUMENTS_DIFFERENCE_INSERT: "INSERT",
+        IGR_COMPARE_DOCUMENTS_DIFFERENCE_DELETE: "DELETE",
+        IGR_COMPARE_DOCUMENTS_DIFFERENCE_FORMATTING: "FORMATTING",
+    }
+
+    with api.OpenExtractor(left_path, IGR_FORMAT_IMAGE, "") as left:
+        with api.OpenExtractor(right_path, IGR_FORMAT_IMAGE, "") as right:
+            with left.Compare(otherDocument=right, compareSettings=settings) as results:
+                diffs = []
+                while results.MoveNext():
+                    diff = results.Current
+                    if diff.Type in (IGR_COMPARE_DOCUMENTS_DIFFERENCE_EQUAL,
+                                     IGR_COMPARE_DOCUMENTS_DIFFERENCE_NEXT_BATCH):
+                        continue
+                    diffs.append({
+                        "type": TYPE_NAMES.get(diff.Type, str(diff.Type)),
+                        "originalPage": diff.OriginalPageIndex + 1,
+                        "revisedPage": diff.RevisedPageIndex + 1,
+                        "parts": [{
+                            "text": hit.Text,
+                            "page": hit.PageIndex + 1,
+                            "bounds": {"l": hit.Bounds.left, "t": hit.Bounds.top,
+                                       "r": hit.Bounds.right, "b": hit.Bounds.bottom},
+                        } for hit in diff.Details]
+                    })
+    return diffs
+
+diffs = compare_documents("v1.docx", "v2.docx")
+print(json.dumps(diffs, indent=2))
+
+# Real-world example: comparing contract revisions to flag changed clauses
+contract_diffs = compare_documents("contract_v1.docx", "contract_v2.docx", ignore_case=True)
+for d in contract_diffs:
+    if d["type"] in ("DELETE", "INSERT"):
+        text = " ".join(p["text"] for p in d["parts"])
+        print(f'[{d["type"]}] page {d["originalPage"]}: {text[:120]}')
+```
+
+## Flags
+
+| Flag | Value | Effect |
+|---|---|---|
+| `IGR_COMPARE_DOCUMENTS_FLAGS_EQUALS` | `0x1` | Include equal/unchanged regions in results |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_MOVES` | `0x10` | Detect moved text blocks (introduces a MOVE diff type — see Notes) |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_FORMATTING` | `0x20` | Report formatting-only differences |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_COMMENTS` | `0x40` | Ignore comments/annotations |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_CASE` | `0x80` | Case-insensitive comparison |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_WHITESPACE` | `0x100` | Ignore whitespace differences |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_PUNCTUATION` | `0x200` | Ignore punctuation |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_TABLES` | `0x400` | Ignore table content |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_HEADERS` | `0x800` | Ignore header regions |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_FOOTERS` | `0x1000` | Ignore footer regions |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_HEADERS_FOOTERS` | `0x1800` | Ignore both headers and footers (combines NO_HEADERS \| NO_FOOTERS) |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_FOOTNOTES` | `0x2000` | Ignore footnotes |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_TEXTBOXES` | `0x4000` | Ignore text box content |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_FIELDS` | `0x8000` | Ignore field content |
+
+## Page Range Filtering
+
+Use `DocumentFilters.CompareDocumentSettings` to limit comparison to specific pages or exclude header/footer areas by pixel margin. Pass settings for **both** documents — omitting either side leaves that document unrestricted:
+
+```python
+left_settings = DocumentFilters.CompareDocumentSettings()
+left_settings.FirstPage = 1
+left_settings.PageCount = 5
+
+right_settings = DocumentFilters.CompareDocumentSettings()
+right_settings.FirstPage = 1
+right_settings.PageCount = 5  # count of pages, not end index — for pages 3-7 use FirstPage=3, PageCount=5
+
+# Use within the outer `with left.Compare(...) as results:` block shown in the main example:
+with left.Compare(otherDocument=right, compareSettings=settings,
+                  thisDocumentSettings=left_settings, otherDocumentSettings=right_settings) as results:
+    while results.MoveNext():
+        ...
+```
+
+`Margins` can also be set on each `CompareDocumentSettings` to exclude regions near page edges (e.g., to skip headers or footers by pixel height).
+
+## Password-Protected Files
+
+Pass the password via the `options` string when opening:
+
+```python
+with api.OpenExtractor(left_path, IGR_FORMAT_IMAGE, options="PASSWORD(secret)") as left:
+    ...
+```
+
+For runtime password prompts (when the password is not known in advance), pass a `callback` to `OpenExtractor`. If a document is encrypted and no password is supplied, `Open()` raises `IGRException`.
+
+## Notes
+
+- **Document comparison requires a license key** — not available in eval (`""`) mode. Set `DF_LICENSE_KEY` or request a free eval key from `DocFiltersEval@hyland.com`.
+- `diff.Type` is an integer. Named constants: `IGR_COMPARE_DOCUMENTS_DIFFERENCE_INSERT` (1), `IGR_COMPARE_DOCUMENTS_DIFFERENCE_DELETE` (2), `IGR_COMPARE_DOCUMENTS_DIFFERENCE_FORMATTING` (3). There is no CHANGE type.
+- When `IGR_COMPARE_DOCUMENTS_FLAGS_MOVES` is enabled, a **MOVE** diff type is also produced. The SDK does not define a named constant for the MOVE difference type — no `IGR_COMPARE_DOCUMENTS_DIFFERENCE_MOVE` constant exists in the public bindings. To discover the value at runtime, add a catch-all branch that prints the raw integer on your first test run: `else: print('Unknown diff type:', diff.Type)`. Once identified, add it to `TYPE_NAMES` (e.g., `IGR_COMPARE_DOCUMENTS_DIFFERENCE_MOVE = <value>`).
+- Not all formats support `IGR_FORMAT_IMAGE` mode. `OpenExtractor` raises `IGRException` for unsupported formats. When processing mixed-format batches, wrap the call in a `try/except`:
+
+```python
+try:
+    diffs = compare_documents("file.txt", "file2.txt")
+except IGRException as e:
+    print(f"Format not supported for comparison: {e}")
+    diffs = []
+```
+
+- Bounding boxes are in points (1/72 inch) relative to the page origin; cast to `int()` when passing to `canvas.Rect()`.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/convert-to-html/skill.md
+++ b/skills/convert-to-html/skill.md
@@ -1,0 +1,164 @@
+---
+name: convert-to-html
+description: Convert any document to HD HTML5 using Document Filters
+---
+
+# Convert a Document to HTML
+
+Hyland Document Filters renders documents to high-definition HTML5 — preserving layout, fonts, and images — from over 600 file formats including Word, PDF, PowerPoint, and email. Processing runs entirely in-process with no external servers or conversion services required, making it suitable for on-premise pipelines and air-gapped environments. This skill is designed for AI engineers building document ingestion pipelines and for teams evaluating browser-based document viewing without third-party cloud services.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+Note: HD HTML output (`IGR_DEVICE_HTML`) requires a valid license key — eval mode raises an error rather than producing watermarked output. Request a free evaluation key at DocFiltersEval@hyland.com.
+
+## Python
+
+### HD HTML5 (layout-preserving)
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def convert_to_html(input_path, output_path, doc_opts="", canvas_opts="HTML_INLINE_IMAGES=on"):
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, doc_opts)
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_HTML, canvas_opts) as canvas:
+            for page in doc.Pages:
+                with page:  # closes the native page handle after rendering
+                    canvas.RenderPage(page)
+
+# Basic conversion
+convert_to_html("report.docx", "report.html")
+
+# In-memory output (no disk I/O — pass html_bytes directly to a downstream service)
+import io
+buf = io.BytesIO()
+with api.GetExtractor("report.docx") as doc:
+    doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+    with api.MakeOutputCanvas(buf, IGR_DEVICE_HTML, "HTML_INLINE_IMAGES=on") as canvas:
+        for page in doc.Pages:
+            with page:
+                canvas.RenderPage(page)
+html_bytes = buf.getvalue()  # bytes — decode("utf-8") if a string is needed
+# io.BytesIO (not io.StringIO) is required because MakeOutputCanvas writes raw bytes
+
+# Optimised for PDFs with tables and complex layout
+convert_to_html(
+    "report.pdf", "report.html",
+    doc_opts="PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on",
+    canvas_opts="HTML_INLINE_IMAGES=on;HDHTML_INCLUDE_WORD_INDEXES=on"
+)
+
+# Page-fragment output (no <html>/<body> wrapper) with injected <head> content
+convert_to_html(
+    "report.docx", "report.html",
+    canvas_opts="HTML_INLINE_IMAGES=on;HDHTML_OUTPUT_BOILERPLATE=off;HDHTML_OUTPUT_INJECT_HEAD=@/path/to/extra_head.html"
+)
+```
+
+### Classic HTML (text extraction, no license required)
+
+Classic HTML uses a document-level streaming API — not per-page page handles. The page count is always 0 when opened with `IGR_FORMAT_HTML`, so iterating `doc.Pages` silently produces empty output.
+
+```python
+def convert_to_classic_html(input_path, output_path):
+    with api.GetExtractor(input_path) as doc:
+        if not doc.getSupportsText():
+            raise ValueError(f"File does not support text extraction: {input_path}")
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_HTML, "")
+        output_dir = os.path.dirname(output_path)
+        with open(output_path, "w", encoding="utf-8") as f:
+            while not doc.getEOF():
+                f.write(doc.GetText(4096, stripControlCodes=True))
+        # Extract embedded images referenced by the HTML
+        for image in doc.Images:
+            with image:
+                image.CopyTo(os.path.join(output_dir, image.getName()))
+
+convert_to_classic_html("report.docx", "report.html")
+```
+
+Note: `HTML_INLINE_IMAGES` has no effect in classic HTML mode — images are always written as separate files in the same directory as the output HTML.
+
+### Async page-on-demand HD HTML (for web apps)
+
+When embedding HD HTML output in a web application, you can render each page as a separate HTML fragment and load them on demand. This avoids generating one large monolithic file.
+
+```python
+def convert_to_html_async(input_path, output_path, canvas_opts="HTML_INLINE_IMAGES=on;HDHTML_INCLUDE_WORD_INDEXES=on"):
+    # main canvas keeps boilerplate (<html>/<body> wrapper); per-page fragments omit it via page_opts
+    page_opts = canvas_opts + ";HDHTML_OUTPUT_BOILERPLATE=off"
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        # binary mode required — MakeOutputCanvas writes raw bytes
+        with open(output_path, "wb") as out_stream:
+            with api.MakeOutputCanvas(out_stream, IGR_DEVICE_HTML, canvas_opts) as canvas:
+                for page_index, page in enumerate(doc.Pages):
+                    with page:
+                        if page_index == 0:
+                            canvas.RenderPage(page)  # first page inline
+                        else:
+                            w, h = page.GetWidth(), page.GetHeight()
+                            page_file = f"{os.path.splitext(output_path)[0]}_page_{page_index + 1}.html"
+                            placeholder = (
+                                f'<div class="idf-page" style="width:{w}px;height:{h}px" '
+                                f'title="{os.path.basename(page_file)}"></div>\n'
+                            )
+                            out_stream.write(placeholder.encode())
+                            with api.MakeOutputCanvas(page_file, IGR_DEVICE_HTML, page_opts) as pc:
+                                pc.RenderPage(page)
+```
+
+See `samples/python/ConvertDocumentToInteractiveHDHTML.py` for the full implementation including CSS/JS injection.
+
+## Options
+
+PDF options are **document-level** — pass them to `doc.Open()`. HTML options are **canvas-level** — pass them to `MakeOutputCanvas()`.
+
+### PDF Input Options (document-level)
+
+| Option                 | Values      | Default | Notes                                                         |
+| ---------------------- | ----------- | ------- | ------------------------------------------------------------- |
+| `PDF_LAYOUT_DETECTION` | `on`, `off` | `off`   | Master switch — enable for better structure detection in PDFs |
+| `PDF_TABLE_DETECTION`  | `on`, `off` | `off`   | Detect tables in PDFs; requires `PDF_LAYOUT_DETECTION=on`     |
+
+### HD HTML Output Options (canvas-level)
+
+| Option                       | Values      | Default | Notes                                                                                 |
+| ---------------------------- | ----------- | ------- | ------------------------------------------------------------------------------------- |
+| `HTML_INLINE_IMAGES`         | `on`, `off` | `off`   | `on` embeds images as base64 data URIs (single self-contained file); `off` writes images as separate files alongside the HTML. The `convert_to_html` helper defaults this to `on` as a convenience. |
+| `HDHTML_INCLUDE_WORD_INDEXES` | `on`, `off` | `off`   | Embeds per-word coordinate data as HTML data attributes, enabling JS-driven text selection, search highlighting, and redaction overlays. Required for AI document Q&A interfaces that need to highlight retrieved passages in the rendered view. |
+| `HDHTML_OUTPUT_BOILERPLATE`  | `on`, `off` | `on`    | `off` omits the `<html>`/`<body>` wrapper — useful when embedding the output as a page fragment |
+| `HDHTML_OUTPUT_INJECT_HEAD`  | `@path`     | —       | Path to a file whose contents are injected into the `<head>` of the output HTML. The `@` prefix is required — it signals that the value is a file path to read, not a literal string. |
+
+## Notes
+
+- **HD HTML output requires a license key** — unlike other formats, `IGR_DEVICE_HTML` is fully blocked in eval mode and will raise an error rather than producing watermarked output. Set `DF_LICENSE_KEY` or request a free eval key from `DocFiltersEval@hyland.com`
+- **`HDHTML_INCLUDE_WORD_INDEXES`** — word coordinates are embedded as data attributes on `<span>` elements using the Document Filters page coordinate space. See `samples/python/ConvertDocumentToInteractiveHDHTML.py` for the JS that maps these to browser coordinates for redaction and highlight overlays.
+- Document Filters has two HTML output modes:
+  - **HD HTML5** (`IGR_DEVICE_HTML` + `RenderPage()`) — canvas-based rendering, layout-preserving, requires a license
+  - **Classic HTML** (`IGR_FORMAT_HTML` + `doc.GetText()`) — text-extraction-based, structure-only, no license required
+- Each page must be used as a context manager (`with page:`) to release native page handles promptly
+- For PDFs with complex layouts, enable `PDF_LAYOUT_DETECTION=on` and `PDF_TABLE_DETECTION=on` together for best table and structure fidelity
+- **Classic HTML** uses a streaming text API (`doc.GetText()` + `doc.getEOF()`), not per-page handles. The page count is always 0 when opened with `IGR_FORMAT_HTML`
+- When `HTML_INLINE_IMAGES=off` (the SDK default), HD HTML output writes image files as separate files alongside the HTML output file. Use `HTML_INLINE_IMAGES=on` to produce a single self-contained HTML file with base64-embedded images.
+- **HD HTML: unsupported or corrupt files** — if a file is not renderable (e.g. a corrupt or unsupported binary), `doc.Open()` raises `IGRException`. Wrap the call in a try/except to produce a meaningful error rather than a bare traceback. (Classic HTML has an equivalent guard via `doc.getSupportsText()`, but the HD HTML path does not.)
+- **Password-protected files**: `doc.Open()` raises `IGRException` when a password is required. Supply the password via a callback:
+  ```python
+  doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "",
+           callback=lambda cb: (cb.Password.SetPassword("secret"), IGR_OK)[1])
+  ```
+  Or pass `callback=...` to `api.GetExtractor()`. Without it, password-protected files raise an `IGRException` with no actionable message.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/convert-to-markdown/skill.md
+++ b/skills/convert-to-markdown/skill.md
@@ -1,0 +1,218 @@
+---
+name: convert-to-markdown
+description: Convert any document to Markdown using Document Filters
+---
+
+# Convert a Document to Markdown
+
+Hyland Document Filters converts 600+ file formats — Office, PDF, CAD, archives, email — to Markdown locally, with no conversion servers or cloud calls. Markdown output preserves headings, tables, images, and document structure, making it the recommended ingestion format for LLM pipelines and RAG systems.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages). Supports 600+ input formats including Word, Excel, PowerPoint, PDF, HTML, CAD, ZIP, PST, MBOX, EML, and more.
+
+## Python
+
+```python
+import io
+import re
+import glob
+import logging
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def convert_to_markdown(input_path, output_path, doc_opts="", canvas_opts=""):
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, doc_opts)
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_MARKDOWN, canvas_opts) as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+
+# Basic conversion
+convert_to_markdown("report.docx", "report.md")
+
+# Optimised for LLM ingestion (GPT flavor, metadata as YAML, unwrap PDF text)
+convert_to_markdown(
+    "report.pdf", "report.md",
+    doc_opts="PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on;PDF_LIST_DETECTION=on",
+    canvas_opts="MARKDOWN_FLAVOR=GPT;MARKDOWN_METADATA_FORMAT=YAML;MARKDOWN_INCLUDE_METADATA=on;MARKDOWN_INCLUDE_FOOTNOTES=on;PDF_MARKDOWN_UNWRAP_TEXT=on"
+)
+
+# Full fidelity (images, charts, formatting)
+convert_to_markdown(
+    "report.pptx", "report.md",
+    canvas_opts="MARKDOWN_INCLUDE_IMAGES=on;MARKDOWN_INCLUDE_CHARTS=on;MARKDOWN_INCLUDE_CHART_TABLE=on;MARKDOWN_INCLUDE_FORMATTING=on"
+)
+
+# In-memory output — MakeOutputCanvas accepts any Python file-like object, no file written to disk
+buf = io.BytesIO()
+convert_to_markdown("report.pdf", buf)
+markdown_text = buf.getvalue().decode("utf-8")
+
+# RAG grounding — inject location comments for citation/source-linking
+def convert_to_markdown_with_locations(input_path, output_path):
+    # PDF_LAYOUT_DETECTION and PDF_TABLE_DETECTION are ignored for non-PDF formats,
+    # so this helper is safe to call on any supported input type.
+    convert_to_markdown(
+        input_path, output_path,
+        doc_opts="PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on",
+        canvas_opts="MARKDOWN_INCLUDE_LOCATIONS=on;MARKDOWN_FLAVOR=GPT"
+    )
+
+convert_to_markdown_with_locations("report.pdf", "report.md")
+
+# Parse LOC comments to pair each text chunk with its page and bounding box.
+# Each <!-- LOC: page, (left,top,right,bottom) --> comment immediately precedes
+# the paragraph it annotates; coordinates are in points (1/72 inch) from top-left.
+LOC_RE = re.compile(r'<!-- LOC: (\d+), \((-?\d+),(-?\d+),(-?\d+),(-?\d+)\) -->')
+
+def parse_markdown_chunks(md_text):
+    """Split location-annotated Markdown into chunks with page/bbox metadata."""
+    chunks = []
+    parts = LOC_RE.split(md_text)
+    # parts layout: [pre-text, page, l, t, r, b, text, page, l, t, r, b, text, ...]
+    # The first element is any content before the first LOC comment (no metadata).
+    i = 1
+    while i + 5 <= len(parts):
+        page, left, top, right, bottom = (int(parts[i]), int(parts[i+1]),
+                                          int(parts[i+2]), int(parts[i+3]),
+                                          int(parts[i+4]))
+        text = parts[i+5].strip() if i + 5 < len(parts) else ""
+        if text:
+            chunks.append({
+                "text": text,
+                "page": page,
+                "bbox": (left, top, right, bottom),
+            })
+        i += 6
+    return chunks
+
+with open("report.md", encoding="utf-8") as f:
+    md = f.read()
+chunks = parse_markdown_chunks(md)
+# Example: [{"text": "Executive Summary\n...", "page": 1, "bbox": (72, 90, 540, 110)}, ...]
+
+# See extract-document-structure for a full parsing example and additional metadata fields.
+
+# Batch conversion with SupportsText guard — skips formats that cannot yield text
+# (e.g. container formats like ZIP, PST, MBOX, EML whose content lives in sub-files).
+def batch_convert_to_markdown(input_paths, output_dir, doc_opts="", canvas_opts=""):
+    os.makedirs(output_dir, exist_ok=True)
+    for input_path in input_paths:
+        try:
+            with api.GetExtractor(input_path) as doc:
+                doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, doc_opts)
+                if not doc.SupportsText:
+                    logging.warning("Skipping %s: format does not support text extraction "
+                                    "(container format — use doc.SubFiles to recurse)", input_path)
+                    continue
+                stem = os.path.splitext(os.path.basename(input_path))[0]
+                output_path = os.path.join(output_dir, stem + ".md")
+                with api.MakeOutputCanvas(output_path, IGR_DEVICE_MARKDOWN, canvas_opts) as canvas:
+                    for page in doc.Pages:
+                        with page:
+                            canvas.RenderPage(page)
+        except IGRException as e:
+            logging.error("Failed to convert %s: %s", input_path, e)
+
+batch_convert_to_markdown(glob.glob("inbox/*"), "output_md")
+```
+
+## Options
+
+PDF options are **document-level** — pass them to `doc.Open()`. Markdown options are **canvas-level** — pass them to `MakeOutputCanvas()`.
+
+### PDF Input Options (document-level)
+
+| Option                     | Values      | Default | Notes                                                                    |
+| -------------------------- | ----------- | ------- | ------------------------------------------------------------------------ |
+| `PDF_LAYOUT_DETECTION`     | `on`, `off` | `off`   | (PDF only) Master switch — enable for better structure detection in PDFs |
+| `PDF_TABLE_DETECTION`      | `on`, `off` | `off`   | (PDF only) Detect tables in PDFs; requires `PDF_LAYOUT_DETECTION=on`     |
+| `PDF_LIST_DETECTION`       | `on`, `off` | `off`   | (PDF only) Detect lists in PDFs; requires `PDF_LAYOUT_DETECTION=on`      |
+
+> Note: `on`/`off` are the canonical values; `true`/`false` are accepted synonyms.
+
+### Markdown Output Options (canvas-level)
+
+#### Flavor & Structure
+
+| Option                           | Values                            | Default | Notes                             |
+| -------------------------------- | --------------------------------- | ------- | --------------------------------- |
+| `MARKDOWN_FLAVOR`                | `GFM`, `GPT`                      | `GFM`   | `GPT` optimises for LLM ingestion |
+| `MARKDOWN_INCLUDE_LOCATIONS`     | `on`, `off`                       | `off`   | Inject `<!-- LOC: page, (left,top,right,bottom) -->` before each paragraph — coordinates are in points (1/72 inch) from the top-left of the page; links text back to its page and bounding box for citation-aware RAG |
+| `MARKDOWN_HEADERS_STYLE`         | `ATX` (`#`), `SETEXT` (underline) | `ATX`   |                                   |
+| `MARKDOWN_PREFERRED_LINE_LENGTH` | integer                           | `80`    | Line wrap length                  |
+| `MARKDOWN_HR_BETWEEN_PAGES`      | `on`, `off`                       | `off`   | Insert `---` between pages        |
+
+#### Tables
+
+| Option                         | Values                                                 | Default | Notes                                     |
+| ------------------------------ | ------------------------------------------------------ | ------- | ----------------------------------------- |
+| `MARKDOWN_SIMPLE_TABLE_STYLE`  | `PIPE`, `GRID`, `HTML`, `PIPE_WITH_HTML`, `PARAGRAPHS` | `PIPE`  |                                           |
+| `MARKDOWN_COMPLEX_TABLE_STYLE` | `PIPE`, `GRID`, `HTML`, `PIPE_WITH_HTML`, `PARAGRAPHS` | `HTML`  | Merged/spanning cells                     |
+| `MARKDOWN_TABLE_PADDING`       | `on`, `off`                                            | `on`    | Padding in pipe-style tables              |
+| `MARKDOWN_TABLE_DETECT_TITLES` | `on`, `off`                                            | `off`   | Treat full-width first row as table title |
+
+#### Content Inclusion
+
+| Option                        | Values               | Default | Notes                            |
+| ----------------------------- | -------------------- | ------- | -------------------------------- |
+| `MARKDOWN_INCLUDE_IMAGES`     | `on`, `off`          | `off`   | Embed images as base64 data URIs |
+| `MARKDOWN_INCLUDE_LINKS`      | `on`, `off`          | `on`    | Preserve hyperlinks              |
+| `MARKDOWN_INCLUDE_FORMATTING` | `on`, `off`          | `on`    | Bold, italic, etc.               |
+| `MARKDOWN_INCLUDE_HEADERS`    | `off`, `on`, `FIRST` | `off`   | Page headers                     |
+| `MARKDOWN_INCLUDE_FOOTERS`    | `off`, `on`, `FIRST` | `off`   | Page footers                     |
+| `MARKDOWN_INCLUDE_FOOTNOTES`  | `on`, `off`          | `off`   | Footnotes and endnotes           |
+| `MARKDOWN_INCLUDE_FORMS`      | `on`, `off`          | `on`    | Form fields                      |
+| `MARKDOWN_INCLUDE_BOOKMARKS`  | `on`, `off`          | `on`    | Document bookmarks               |
+| `MARKDOWN_INCLUDE_FIELDS`     | `on`, `off`          | `on`    | Field codes                      |
+
+#### Metadata
+
+| Option                      | Values                                     | Default    | Notes                                                                                        |
+| --------------------------- | ------------------------------------------ | ---------- | -------------------------------------------------------------------------------------------- |
+| `MARKDOWN_INCLUDE_METADATA` | `on`, `off`                                | `off`      | Prepend document metadata                                                                    |
+| `MARKDOWN_METADATA_FORMAT`  | `COMMENTS`, `YAML`, `TOML`, `JSON`, `None` | `COMMENTS` | Format for metadata block; `None` includes metadata as a plain block with no format wrapper. Only takes effect when `MARKDOWN_INCLUDE_METADATA=on` is set. |
+
+#### Charts
+
+| Option                         | Values      | Default | Notes                           |
+| ------------------------------ | ----------- | ------- | ------------------------------- |
+| `MARKDOWN_INCLUDE_CHARTS`      | `on`, `off` | `off`   | Master switch for chart data    |
+| `MARKDOWN_INCLUDE_CHART_TABLE` | `on`, `off` | `off`   | Chart data as Markdown table    |
+| `MARKDOWN_INCLUDE_CHART_JSON`  | `on`, `off` | `off`   | Chart data as JSON fenced block |
+
+#### PDF-specific canvas options
+
+| Option                     | Values      | Default | Notes                                                          |
+| -------------------------- | ----------- | ------- | -------------------------------------------------------------- |
+| `PDF_MARKDOWN_UNWRAP_TEXT` | `on`, `off` | `off`   | (PDF only) Unwrap hard-wrapped lines in PDFs for cleaner prose |
+
+#### Cleanup
+
+| Option                   | Values                                                          | Default | Notes                                      |
+| ------------------------ | --------------------------------------------------------------- | ------- | ------------------------------------------ |
+| `MARKDOWN_CLEAN_CONTENT` | `clean_non_ascii_chars`, `normalize_quotes`, `normalize_dashes` | —       | Comma-separated list of cleaning functions, e.g. `MARKDOWN_CLEAN_CONTENT=clean_non_ascii_chars,normalize_quotes` |
+
+## Notes
+
+- Eval mode limits output to the first few pages with a watermark; the following options require a valid license key: `MARKDOWN_FLAVOR=GPT`, `MARKDOWN_INCLUDE_CHARTS`, `MARKDOWN_INCLUDE_IMAGES`, `MARKDOWN_INCLUDE_LOCATIONS`, and PDF detection options (`PDF_LAYOUT_DETECTION`, `PDF_TABLE_DETECTION`, `PDF_LIST_DETECTION`) — eval mode only supports basic GFM output
+- `MARKDOWN_FLAVOR=GPT` produces cleaner output for LLM ingestion — fewer decorative elements, plainer structure
+- `MARKDOWN_METADATA_FORMAT` has no effect unless `MARKDOWN_INCLUDE_METADATA=on` is also set
+- For PDFs with complex layouts, enable `PDF_LAYOUT_DETECTION=on` and `PDF_TABLE_DETECTION=on` together for best table fidelity
+- For container formats (ZIP, PST, MBOX, EML), content is in sub-files — use `doc.SubFiles` to iterate and recursively extract each sub-document; iterating `doc.Pages` on these formats will produce empty output. Always call `doc.SupportsText` after `doc.Open()` in a batch loop and skip (or log a warning for) documents where it returns `False`
+- Wrap `doc.Open()` in a `try/except IGRException` block to skip unsupported formats gracefully in batch conversion. Note: file-not-found also raises `IGRException` (not Python's `FileNotFoundError`) — check path existence beforehand or catch `IGRException` for all file I/O errors
+- For password-protected files, set `doc.PasswordCallback = lambda id: os.environ.get("DOC_PASSWORD", "")` before calling `doc.Open()`. An incorrect or missing password raises `IGRException`
+- For AI ingestion, canvas-based Markdown output (`MARKDOWN_FLAVOR=GPT`) preserves document structure — headings, tables, and lists — that is lost with plain `GetText()` extraction. Prefer this skill over raw text extraction when document structure matters for your LLM
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/convert-to-pdf/skill.md
+++ b/skills/convert-to-pdf/skill.md
@@ -1,0 +1,124 @@
+---
+name: convert-to-pdf
+description: Convert any document to PDF using Document Filters
+---
+
+# Convert a Document to PDF
+
+Document Filters converts Word, Excel, PowerPoint, CAD, email archives, and 600+ other formats to PDF — locally, with no LibreOffice and no cloud API, just `pip install`. This makes it a strong fit for air-gapped environments, high-throughput pipelines, and any workflow where external dependencies are not an option. The output is a standard PDF file. When the input is already a PDF, pass `PDF_PRESERVE_ORIGINAL=on` to preserve vector content; otherwise, pages are rendered at high resolution.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+## Python
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def convert_to_pdf(input_path, output_path, bookmarks=False, open_options=""):
+    # PDF_BOOKMARKS must be passed to Open(), not MakeOutputCanvas()
+    open_opts = f"PDF_BOOKMARKS={str(bookmarks).lower()}"
+    if open_options:
+        open_opts += f";{open_options}"
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, open_opts)
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PDF, "") as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+
+convert_to_pdf("report.docx", "report.pdf")
+convert_to_pdf("report.docx", "report.pdf", bookmarks=True)
+# multi-column PDFs or PDFs with tables: improves text-flow and cell extraction for downstream text use
+convert_to_pdf("report.pdf", "report_out.pdf", open_options="PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on")
+
+# In-memory output — write PDF bytes to a buffer instead of a file
+# MakeOutputCanvas accepts either a file path (str) or an IGRStream subclass.
+# Plain io.BytesIO() is NOT accepted directly — wrap it in a subclass of IGRStream.
+import io
+
+class BytesIOStream(IGRStream):
+    def __init__(self):
+        super().__init__()
+        self._buf = io.BytesIO()
+    def Read(self, length):
+        return self._buf.read(length)
+    def Write(self, data):
+        self._buf.write(data)
+        return len(data)
+    def Seek(self, offset, whence):
+        return self._buf.seek(offset, whence)
+    def Tell(self):
+        return self._buf.tell()
+    def getvalue(self):
+        self._buf.seek(0)
+        return self._buf.read()
+
+def convert_to_pdf_bytes(input_path, open_options=""):
+    stream = BytesIOStream()
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, open_options)
+        with api.MakeOutputCanvas(stream, IGR_DEVICE_IMAGE_PDF, "") as canvas:
+            page_count = 0
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+                    page_count += 1
+        if page_count == 0:
+            raise ValueError(f"No pages rendered from {input_path!r}. The document may be empty or the format does not support image rendering.")
+    return stream.getvalue()
+
+pdf_bytes = convert_to_pdf_bytes("report.docx")
+# pdf_bytes is a bytes object — store in object storage, pass to a model, etc.
+
+# Combine multiple documents into a single PDF
+# PDF_PRESERVE_ORIGINAL=on keeps existing PDF pages as vectors; without it they are rasterized
+def combine_to_pdf(input_paths, output_path):
+    with api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PDF, "PDF_PRESERVE_ORIGINAL=on") as canvas:
+        for path in input_paths:
+            with api.GetExtractor(path) as doc:
+                doc.Open(IGR_FORMAT_IMAGE, "")
+                for page in doc.Pages:
+                    with page:
+                        canvas.RenderPage(page)
+
+combine_to_pdf(["chapter1.docx", "chapter2.docx", "appendix.xlsx"], "combined.pdf")
+
+# Password-protected files: set PasswordCallback before calling Open()
+def convert_protected_pdf(input_path, output_path, password):
+    with api.GetExtractor(input_path) as doc:
+        doc.PasswordCallback = lambda doc_id: password
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PDF, "") as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+```
+
+## Notes
+
+- Internally, Document Filters opens the source file in image mode (`IGR_FORMAT_IMAGE`) and renders each page to a PDF canvas. When the input is already a PDF and `PDF_PRESERVE_ORIGINAL=on` is set, the original vector content is preserved rather than rasterized.
+- `IGR_FORMAT_IMAGE` is required in `Open()` to enable page rendering. `IGR_BODY_AND_META` alone (without `IGR_FORMAT_IMAGE`) is for text extraction. The examples above use `IGR_BODY_AND_META | IGR_FORMAT_IMAGE` — the `IGR_BODY_AND_META` flag is optional for a pure render but harmless and makes it easier to add text extraction later without reopening the document. For a pure page-render combine (no text access needed), `IGR_FORMAT_IMAGE` alone is sufficient.
+- `PDF_BOOKMARKS=true` generates a navigable bookmark tree in the output PDF from heading styles in the source document (applies to Word, PowerPoint, PDF, and any format with structural headings). Pass it as an option to `Open()`, not to `MakeOutputCanvas()`. Option values are case-insensitive; `true`/`false`, `on`/`off`, and `1`/`0` are all accepted.
+- `PDF_PRESERVE_ORIGINAL=on` preserves existing PDF page content as vectors when combining documents. Without it, PDF pages in input files are rasterized, causing quality loss. Pass this to `MakeOutputCanvas()`.
+- `PDF_LAYOUT_DETECTION=on` improves column and text-flow detection in multi-column PDFs. Pass to `Open()`.
+- `PDF_TABLE_DETECTION=on` improves table cell extraction in PDFs. Pass to `Open()`.
+- Multiple options are separated by semicolons: `"PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on"`.
+- If a file does not exist or its format is unsupported, `GetExtractor()` or `Open()` raises an `IGRException`. Wrap calls in `try/except IGRException`. Document Filters does not expose a pre-open rendering-capability flag. Call `doc.Open(IGR_FORMAT_IMAGE, "")` and check that `doc.Pages` yields at least one page before writing output. `IGRException` will be raised for completely unsupported formats. Note: `getSupportsText()` tests for text-extraction support (`IGR_FILE_SUPPORTS_TEXT`) and is unrelated to rendering — do not use it as a render-capability check.
+- If `doc.Pages` yields no pages (empty document, or a text-only format opened with `IGR_FORMAT_IMAGE`), the output canvas will contain an empty or invalid PDF. Check the page count during iteration and raise an error or skip writing the output file if zero pages are rendered.
+- For password-protected files, set `doc.PasswordCallback = lambda doc_id: 'password'` before calling `Open()`. Without a callback, encrypted files raise an `IGRException`.
+- Each `api.GetExtractor()` handle is single-use. To re-process a document, create a new extractor — do not call `doc.Open()` a second time on the same handle.
+- Eval mode limits output to the first few pages.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/convert-to-png/skill.md
+++ b/skills/convert-to-png/skill.md
@@ -1,0 +1,115 @@
+---
+name: convert-to-png
+description: Render each page of a document as a PNG image using Document Filters
+---
+
+# Convert a Document to PNG Images
+
+When building AI pipelines that pass document pages to vision models or multimodal LLMs, you need reliable, high-fidelity PNG renders from any file format. Hyland Document Filters renders pages from 600+ formats — PDFs, Office documents, email archives, CAD drawings, and more — into PNG images, locally, with no conversion server required.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode.
+
+For production-quality rendering, set `ISYS_FONTS` and `ISYS_ASSETS` to the path of the downloaded font assets. Without this, output may have garbled or substituted fonts. See the use-document-filters-api skill for download instructions.
+
+## Python
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def convert_to_png(input_path, output_prefix):
+    """Renders each page to <output_prefix>_page1.png, _page2.png, etc."""
+    with api.GetExtractor(input_path) as doc:
+        # IGR_FORMAT_IMAGE is required; without it, doc.Pages will be empty (text-extraction mode)
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "GRAPHIC_DPI=150")
+        page_count = doc.GetPageCount()
+        if page_count == 0:
+            raise ValueError(f"Document '{input_path}' yielded no renderable pages")
+        for i, page in enumerate(doc.Pages, start=1):
+            with page:
+                out = f"{output_prefix}_page{i}.png"
+                with api.MakeOutputCanvas(out, IGR_DEVICE_IMAGE_PNG, "") as canvas:
+                    canvas.RenderPage(page)
+                print(f"Wrote {out}")
+
+convert_to_png("slides.pptx", "slide")
+# Produces: slide_page1.png, slide_page2.png, ...
+```
+
+See the Options table below to control resolution or pixel dimensions.
+
+### Render pages to in-memory bytes
+
+`MakeOutputCanvas` accepts either a file path string or an `io.IOBase` object. Pass an `io.BytesIO()` directly to capture PNG bytes in memory — useful for passing pages directly to Pillow, base64-encoding for a vision API, or any pipeline that should avoid writing temp files.
+
+```python
+import io
+import base64
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def pages_as_png_bytes(input_path):
+    """Yields raw PNG bytes for each page, without writing any files."""
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "GRAPHIC_DPI=150")
+        for page in doc.Pages:
+            with page:
+                buf = io.BytesIO()
+                with api.MakeOutputCanvas(buf, IGR_DEVICE_IMAGE_PNG, "") as canvas:
+                    canvas.RenderPage(page)
+                yield buf.getvalue()
+
+for png_bytes in pages_as_png_bytes("slides.pptx"):
+    b64 = base64.b64encode(png_bytes).decode("utf-8")
+    # pass b64 to a vision API, or: Image.open(io.BytesIO(png_bytes))
+```
+
+## Options
+
+Size and DPI options are passed as the second argument to `doc.Open()`, not to `MakeOutputCanvas()`. Options are semicolon-separated.
+
+| Option           | Description                                             | Example                  |
+| ---------------- | ------------------------------------------------------- | ------------------------ |
+| `GRAPHIC_DPI=N`  | Output resolution. Default is 96 DPI (too low for most use cases). Use 150 for screen, 300 for print. | `"GRAPHIC_DPI=150"` |
+| `GRAPHIC_WIDTH=N` | Scale each page to N pixels wide.                      | `"GRAPHIC_WIDTH=2000"`   |
+| `GRAPHIC_HEIGHT=N` | Scale each page to N pixels tall.                     | `"GRAPHIC_HEIGHT=2000"`  |
+| `GRAPHIC_BPP=N`  | Bits per pixel. Common values: `1` (bitonal), `8` (grayscale), `24` (RGB, default). Use `8` to reduce image size for OCR or vision pipelines. | `"GRAPHIC_BPP=8"` |
+
+Example combining options (semicolon-separated):
+
+```python
+doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "GRAPHIC_DPI=150;GRAPHIC_WIDTH=2000")
+```
+
+When both `GRAPHIC_WIDTH` and `GRAPHIC_HEIGHT` are set, Document Filters preserves the aspect ratio and clamps to whichever dimension is more constraining — the page will not be distorted.
+
+## Notes
+
+- Each page produces one PNG file; there is no single-file PNG output for multi-page documents
+- If a document yields no pages, the loop completes silently. Call `doc.GetPageCount()` after `doc.Open()` to verify the page count before iterating, or check that `len(list(doc.Pages)) > 0`.
+- Eval mode adds an "Evaluation Copy" watermark to every page and limits input formats to Text, PDF, and Microsoft/OpenDocument Office files. Set `DF_LICENSE_KEY` to remove these restrictions.
+- Unsupported formats, missing files, and corrupted documents raise `IGRException`. Wrap calls in `try/except IGRException` to handle gracefully.
+- For password-protected files, set a `PasswordCallback` on an `OpenCallback` instance and pass it to `doc.Open()`:
+  ```python
+  from DocumentFilters import *
+  cb = OpenCallback()
+  cb.PasswordCallback = lambda doc_id: "secret"
+  doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "GRAPHIC_DPI=150", cb)
+  ```
+  Without a callback, `doc.Open()` raises `IGRException` for encrypted documents.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/document-filters-api.instructions.md
+++ b/skills/document-filters-api.instructions.md
@@ -1,0 +1,908 @@
+---
+applyTo: "**"
+---
+
+# Hyland Document Filters SDK Guide
+
+Comprehensive documentation for the Hyland Document Filters SDK — a powerful document processing toolkit for file inspection, text extraction, content conversion, and document comparison across 600+ file formats.
+
+---
+
+## Table of Contents
+
+1. [Overview](#overview)
+2. [Licensing](#licensing)
+3. [Installation](#installation)
+   - [Python Bindings](#python-bindings)
+   - [Native Runtime Binaries](#native-runtime-binaries)
+   - [Assets & Fonts](#assets--fonts)
+4. [Initialization](#initialization)
+5. [Core Capabilities](#core-capabilities)
+   - [File Type Identification](#file-type-identification)
+   - [Text Extraction](#text-extraction)
+   - [HTML Conversion (High-Fidelity)](#html-conversion-high-fidelity)
+   - [PDF Conversion](#pdf-conversion)
+   - [Image Rendering (PNG/TIFF)](#image-rendering-pngtiff)
+   - [Document Comparison](#document-comparison)
+   - [Metadata Extraction](#metadata-extraction)
+   - [Sub-File Extraction](#sub-file-extraction)
+6. [Python API Reference](#python-api-reference)
+   - [DocumentFilters Class](#documentfilters-class)
+   - [Extractor](#extractor)
+   - [Pages & Canvas](#pages--canvas)
+   - [Compare API](#compare-api)
+   - [Constants & Flags](#constants--flags)
+7. [Canvas Options](#canvas-options)
+8. [Environment Variables](#environment-variables)
+9. [Supported Platforms](#supported-platforms)
+10. [Best Practices & Pitfalls](#best-practices--pitfalls)
+11. [Error Handling](#error-handling)
+12. [Code Examples](#code-examples)
+13. [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+Hyland Document Filters is an SDK that provides developers with tools to embed rich document processing capabilities into applications. It operates as a local library (not a REST API) with native binaries for each platform and language bindings for Python, C#, Java, and C/C++.
+
+### Key Features
+
+- **Deep Content Inspection** — Identify file types and extract text, metadata, and structure from 600+ formats
+- **High-Fidelity Rendering** — Convert documents to HTML5, PDF, PNG, TIFF, and other output formats
+- **Document Comparison** — Word-level comparison of two documents with bounding box location data
+- **Content Transformation** — Combine pages from multiple documents, apply watermarks, redactions, and annotations
+- **OCR Support** — Optical Character Recognition for scanned documents and images
+- **Markdown & JSON Output** — Convert documents to Markdown and structured MDAST JSON
+- **Cross-Platform** — Runs on Windows, Linux (x64/ARM), macOS (Intel/ARM), and FreeBSD
+
+### Resources
+
+| Resource                 | URL                                                                                                                    |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| Home Page                | https://www.documentfilters.com                                                                                        |
+| Documentation            | https://hyland.github.io/DocumentFilters-Docs/latest/                                                                  |
+| API Reference            | https://hyland.github.io/DocumentFilters-Docs/latest/reference.html                                                    |
+| Python Getting Started   | https://hyland.github.io/DocumentFilters-Docs/latest/getting_started_with_document_filters/getting_started_python.html |
+| GitHub (Public)          | https://github.com/Hyland/DocumentFilters                                                                              |
+| GitHub (Internal Source) | https://github.com/HylandExperience/cin-docfilters                                                                     |
+| Release Notes            | https://hyland.github.io/DocumentFilters-Docs/latest/release_notes/index.html                                          |
+| Security Hub             | https://hyland.github.io/DocumentFilters-SecurityHub/                                                                  |
+| Supported Formats        | https://hyland.github.io/DocumentFilters-Docs/latest/supported_platforms.html                                          |
+
+---
+
+## Licensing
+
+Document Filters supports three licensing modes:
+
+| Mode                           | License Key         | Features | Expiration |
+| ------------------------------ | ------------------- | -------- | ---------- |
+| **Full Featured**              | REQUIRED            | ALL      | _Optional_ |
+| **Time-Limited Evaluation**    | REQUIRED            | ALL      | REQUIRED   |
+| **Feature-Limited Evaluation** | NONE (empty string) | LIMITED  | NONE       |
+
+### Feature-Limited Evaluation
+
+When no license key is provided (empty string `""`), the following limitations apply:
+
+- **Supported input formats** (for processing beyond file identification): Text, PDF, Microsoft Office (Word, Excel, PowerPoint), OpenDocument Format (ODF)
+- **Supported output formats**: Text, PDF, Raster images (PNG, JPEG, GIF, WEBP, BMP, TIFF), Markdown
+- **Watermark**: Each page of output contains an "Evaluation Copy" watermark
+
+File type identification (`getFileType()`) is **not** restricted in evaluation mode.
+
+### Requesting a License
+
+- **Evaluation license**: Email `DocFiltersEval@hyland.com`
+- **Full license**: Contact [Hyland Sales](https://www.hyland.com/en/company/contact-us) and enter into an OEM Agreement
+
+### License Key Configuration
+
+Store the license key in an environment variable and load it at initialization:
+
+```env
+DF_LICENSE_KEY=XXXXX XXXXX XXXXX XXXXX XXXXX XXXXX
+```
+
+---
+
+## Installation
+
+### Python Bindings
+
+Install from GitHub via pip:
+
+```bash
+pip install DocumentFilters@git+https://github.com/Hyland/DocumentFilters.git@v26.1.0#subdirectory=bindings/python
+```
+
+Or add to `requirements.txt`:
+
+```text
+DocumentFilters @ git+https://github.com/Hyland/DocumentFilters.git@v26.1.0#subdirectory=bindings/python
+```
+
+Replace `v26.1.0` with the desired version tag (latest release: `v26.1.0`).
+
+### Native Runtime Binaries
+
+The Python package does **not** bundle native shared libraries. These must be downloaded separately and provided at initialization time via the `dll_path` parameter.
+
+Binaries are available as GitHub Release assets:
+
+```
+https://github.com/Hyland/DocumentFilters/releases/download/v{VERSION}/{ARTIFACT}.zip
+```
+
+#### Platform Artifact Names
+
+| Platform | Architecture          | Artifact Name                 |
+| -------- | --------------------- | ----------------------------- |
+| Windows  | x64                   | `windows-intel-msvc-64`       |
+| Windows  | x86                   | `windows-intel-msvc-32`       |
+| Linux    | x64 (glibc)           | `linux-intel-gcc-64`          |
+| Linux    | x64 (musl)            | `linux-intel-clang-musl-64`   |
+| Linux    | ARM64 (glibc)         | `linux-aarch64-gcc-64`        |
+| Linux    | ARM64 (musl)          | `linux-aarch64-clang-musl-64` |
+| macOS    | ARM64 (Apple Silicon) | `macos-arm64-clang-64`        |
+| macOS    | x64 (Intel)           | `macos-intel-clang-64`        |
+
+It is recommended to cache downloaded binaries locally (e.g., in `runtimes/{VERSION}/{ARTIFACT}/`) to avoid re-downloading.
+
+### Assets & Fonts
+
+Font assets are also required for rendering and are downloaded separately:
+
+```
+https://github.com/Hyland/DocumentFilters/releases/download/v{VERSION}/assets.zip
+```
+
+Extracted to `runtimes/{VERSION}/assets/` and referenced via the `ISYS_FONTS` and `ISYS_ASSETS` environment variables.
+
+---
+
+## Initialization
+
+The Document Filters engine must be initialized once before use. The three required inputs are:
+
+1. **License key** — string (empty for evaluation mode)
+2. **Working directory** — typically `"."`
+3. **Runtime path** — path to the directory containing native binaries
+
+```python
+from DocumentFilters import DocumentFilters
+
+api = DocumentFilters()
+
+# Set font/asset paths
+os.environ['ISYS_FONTS'] = '/path/to/assets'
+os.environ['ISYS_ASSETS'] = '/path/to/assets'
+
+# Initialize the engine
+api.Initialize(license_key, ".", "/path/to/runtime/binaries")
+```
+
+### Recommended Initialization Steps
+
+1. Read `DF_LICENSE_KEY` from environment variables
+2. Download runtime binaries for the current platform if not cached locally
+3. Download font assets if not cached locally
+4. Set `ISYS_FONTS` and `ISYS_ASSETS` environment variables
+5. Call `api.Initialize(license_key, ".", runtime_path)`
+
+A singleton or module-level instance is recommended since the engine only needs to be initialized once.
+
+---
+
+## Core Capabilities
+
+### File Type Identification
+
+Identify a file's format without fully opening it. Works on 600+ formats and is unrestricted in evaluation mode.
+
+```python
+with api.GetExtractor("document.pdf") as extractor:
+    file_type_id = extractor.getFileType()                        # Numeric type ID
+    file_type_name = extractor.getFileType(IGR_FORMAT_LONG_NAME)  # Human-readable name
+    supports_text = extractor.getSupportsText()                   # Boolean
+    supports_subfiles = extractor.getSupportsSubFiles()           # Boolean (e.g., ZIP, email)
+```
+
+### Text Extraction
+
+Extract plain text from documents.
+
+```python
+with api.GetExtractor("document.pdf") as extractor:
+    if extractor.getSupportsText():
+        extractor.Open(IGR_BODY_AND_META)
+        while not extractor.getEOF():
+            text = extractor.GetText(4096, stripControlCodes=True)
+            print(text)
+```
+
+Check `getSupportsText()` before the loop — rendering-only formats (e.g., scanned TIFF without OCR) open successfully but return no text. Without the guard, callers get an empty result with no indication of failure.
+
+### Idiomatic Short-Form: `OpenExtractor()`
+
+`api.OpenExtractor(source, mode, options)` combines `GetExtractor` and `Open` in one call and is the preferred form when no per-file `Open` customisation is needed:
+
+```python
+with api.OpenExtractor("document.pdf", IGR_BODY_AND_META) as extractor:
+    if extractor.getSupportsText():
+        while not extractor.getEOF():
+            print(extractor.GetText(4096))
+```
+
+The `callback` parameter on `OpenExtractor` is the only path to supply a password callback before `Open()` is invoked (see Error Handling below).
+
+### HTML Conversion (High-Fidelity)
+
+Convert documents to high-definition, paginated HTML5 with inline images. **Requires a license** for full HTML output (evaluation mode only supports PDF and raster output).
+
+```python
+with api.GetExtractor("document.pdf") as extractor:
+    extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+    with api.MakeOutputCanvas("output.html", IGR_DEVICE_HTML, "HTML_INLINE_IMAGES=on") as canvas:
+        for page in extractor.Pages:
+            canvas.RenderPage(page)
+```
+
+### PDF Conversion
+
+```python
+with api.GetExtractor("document.docx") as extractor:
+    extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+    with api.MakeOutputCanvas("output.pdf", IGR_DEVICE_IMAGE_PDF, "") as canvas:
+        for page in extractor.Pages:
+            canvas.RenderPage(page)
+```
+
+### Image Rendering (PNG/TIFF)
+
+Render individual pages as images.
+
+```python
+with api.GetExtractor("document.pdf") as extractor:
+    extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+    for i, page in enumerate(extractor.Pages):
+        with api.MakeOutputCanvas(f"page_{i}.png", IGR_DEVICE_IMAGE_PNG, "") as canvas:
+            canvas.RenderPage(page)
+```
+
+### Document Comparison
+
+Compare two documents word-by-word and get difference details with bounding box locations. **Requires a license.**
+
+```python
+compare_settings = DocumentFilters.CompareSettings()
+compare_settings.CompareType = IGR_COMPARE_DOCUMENTS_COMPARE_WORDS
+compare_settings.Flags = 0  # Add flags as needed (see Constants section)
+
+with api.GetExtractor("original.pdf") as left:
+    left.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+    with api.GetExtractor("revised.pdf") as right:
+        right.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+        with left.Compare(otherDocument=right, compareSettings=compare_settings) as results:
+            while results.MoveNext():
+                diff = results.Current
+
+                if diff.Type in (IGR_COMPARE_DOCUMENTS_DIFFERENCE_EQUAL,
+                                 IGR_COMPARE_DOCUMENTS_DIFFERENCE_NEXT_BATCH):
+                    continue
+
+                print(f"Type: {diff.Type}")
+                print(f"Original Page: {diff.OriginalPageIndex + 1}")
+                print(f"Revised Page: {diff.RevisedPageIndex + 1}")
+                print(f"Text: {diff.GetText()}")
+
+                for hit in diff.Details:
+                    print(f"  Part: '{hit.Text}' at page {hit.PageIndex + 1}")
+                    print(f"  Bounds: ({hit.Bounds.left}, {hit.Bounds.top}, "
+                          f"{hit.Bounds.right}, {hit.Bounds.bottom})")
+```
+
+### Metadata Extraction
+
+Extract document metadata (author, title, dates, etc.) when opening with `IGR_BODY_AND_META`.
+
+### Sub-File Extraction
+
+Extract embedded files from containers (ZIP, email, PST, etc.):
+
+```python
+with api.GetExtractor("archive.zip") as extractor:
+    if extractor.getSupportsSubFiles():
+        for subfile in extractor.SubFiles:
+            with subfile:
+                # Open must be called inside the with block, before reading text
+                text = ""
+                if subfile.getSupportsText():
+                    subfile.Open(IGR_BODY_AND_META)
+                    while not subfile.getEOF():
+                        text += subfile.GetText(4096)
+```
+
+---
+
+## Python API Reference
+
+### DocumentFilters Class
+
+The main entry point for the SDK.
+
+| Method                                                     | Description                                                                                                        |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `Initialize(license_key, working_dir, dll_path)`           | Initialize the engine. Must be called before any other operations.                                                 |
+| `GetExtractor(source)`                                     | Create an extractor for a file path, bytes, or file-like object. Returns a context manager.                        |
+| `OpenExtractor(source, mode=IGR_BODY_AND_META, options="", callback=None)` | Combines `GetExtractor` and `Open` in one call. Preferred when no per-file `Open` customisation is needed. |
+| `MakeOutputCanvas(filename, device_type, options)`         | Create an output canvas for rendering. Returns a context manager.                                                  |
+
+### Extractor
+
+Returned by `GetExtractor()`. Use as a context manager (`with` statement).
+
+| Method/Property                                | Description                                                           |
+| ---------------------------------------------- | --------------------------------------------------------------------- |
+| `getFileType(format?)`                         | Get file type. Pass `IGR_FORMAT_LONG_NAME` for human-readable string. |
+| `getSupportsText()`                            | Returns `True` if text extraction is supported.                       |
+| `getSupportsSubFiles()`                        | Returns `True` if the file contains sub-files (archives, email).      |
+| `Open(flags, options?)`                        | Open the document for processing.                                     |
+| `getEOF()`                                     | Returns `True` when all text has been read.                           |
+| `GetText(max_chars, stripControlCodes?)`       | Read text from the document.                                          |
+| `Pages`                                        | Iterable of page objects for rendering.                               |
+| `SubFiles`                                     | Iterable of sub-file extractors.                                      |
+| `Compare(otherDocument, compareSettings, ...)` | Compare with another extractor. Returns comparison results.           |
+
+### Pages & Canvas
+
+| Canvas Method                    | Description                           |
+| -------------------------------- | ------------------------------------- |
+| `RenderPage(page)`               | Render a page to the canvas output.   |
+| `SetBrush(color, style)`         | Set brush for drawing operations.     |
+| `SetPen(color, width, style)`    | Set pen for drawing operations.       |
+| `Rect(left, top, right, bottom)` | Draw a rectangle (for highlighting).  |
+| `Close()`                        | Close the canvas and finalize output. |
+
+### Compare API
+
+| Class/Method                                | Description                                                             |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| `DocumentFilters.CompareSettings()`         | Settings object for comparison.                                         |
+| `.CompareType`                              | Set to `IGR_COMPARE_DOCUMENTS_COMPARE_WORDS` for word-level comparison. |
+| `.Flags`                                    | Bitwise OR of `IGR_COMPARE_DOCUMENTS_FLAGS_*` constants.                |
+| `DocumentFilters.CompareDocumentSettings()` | Per-document settings (page ranges, margins).                           |
+| `.FirstPage`                                | First page to compare (0-based).                                        |
+| `.PageCount`                                | Number of pages to compare.                                             |
+| `.Margins`                                  | `IGR_FRect` for margin exclusion.                                       |
+| `results.MoveNext()`                        | Advance to next difference. Returns `False` when done.                  |
+| `results.Current`                           | Current difference object.                                              |
+| `diff.Type`                                 | Difference type (see constants below).                                  |
+| `diff.OriginalPageIndex`                    | Page index in original document (0-based).                              |
+| `diff.RevisedPageIndex`                     | Page index in revised document (0-based).                               |
+| `diff.GetText()`                            | Get text content of the difference.                                     |
+| `diff.Details`                              | Iterable of detail parts with `.Text`, `.PageIndex`, `.Bounds`.         |
+
+### Constants & Flags
+
+#### Open Flags
+
+| Constant                              | Description                                                                                                                        |
+| ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `IGR_BODY_AND_META`                   | Extract body text and metadata                                                                                                     |
+| `IGR_FORMAT_IMAGE`                    | Enable page rendering. Use alone when only rendering is needed (e.g., pure canvas workflows). Combine with `IGR_BODY_AND_META` (`IGR_BODY_AND_META \| IGR_FORMAT_IMAGE`) to enable both text extraction and rendering. |
+
+#### Output Devices
+
+| Constant                    | Description                                                                                                              |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `IGR_DEVICE_HTML`           | High-definition HTML5 output                                                                                             |
+| `IGR_DEVICE_IMAGE_PNG`      | PNG image output                                                                                                         |
+| `IGR_DEVICE_IMAGE_PDF`      | PDF output                                                                                                               |
+| `IGR_DEVICE_IMAGE_TIFF`     | TIFF image output                                                                                                        |
+| `IGR_DEVICE_MARKDOWN`       | Markdown output                                                                                                          |
+| `IGR_DEVICE_STRUCTURED_XML` | Page-level XML with word bounding-box data — useful for downstream NLP; not plain text                                   |
+| `IGR_DEVICE_JSON`           | MDAST JSON with word locations (enable `JSON_INCLUDE_WORD_LOCATIONS=on`); page-level structure, not a plain text extract |
+
+#### File Type Formats
+
+| Constant               | Description                          |
+| ---------------------- | ------------------------------------ |
+| `IGR_FORMAT_LONG_NAME` | Return human-readable file type name |
+
+#### Comparison Flags
+
+| Constant                                     | Description                |
+| -------------------------------------------- | -------------------------- |
+| `IGR_COMPARE_DOCUMENTS_COMPARE_WORDS`        | Word-level comparison      |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_CASE`        | Ignore case differences    |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_FIELDS`      | Exclude fields             |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_FOOTERS`     | Exclude footers            |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_HEADERS`     | Exclude headers            |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_PUNCTUATION` | Exclude punctuation        |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_TABLES`      | Exclude tables             |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_NO_TEXTBOXES`   | Exclude textboxes          |
+| `IGR_COMPARE_DOCUMENTS_FLAGS_FORMATTING`     | Include formatting changes |
+
+#### Difference Types
+
+| Constant                                      | Description                                |
+| --------------------------------------------- | ------------------------------------------ |
+| `IGR_COMPARE_DOCUMENTS_DIFFERENCE_EQUAL`      | Content is equal (skip)                    |
+| `IGR_COMPARE_DOCUMENTS_DIFFERENCE_NEXT_BATCH` | Batch boundary marker (skip)               |
+| `IGR_COMPARE_DOCUMENTS_DIFFERENCE_INSERT`     | Content was inserted in revised document   |
+| `IGR_COMPARE_DOCUMENTS_DIFFERENCE_DELETE`     | Content was deleted from original document |
+| `IGR_COMPARE_DOCUMENTS_DIFFERENCE_FORMATTING` | Formatting-only change                     |
+
+#### Drawing Constants
+
+| Constant          | Description         |
+| ----------------- | ------------------- |
+| `IGR_BRUSH_SOLID` | Solid brush fill    |
+| `IGR_PEN_NONE`    | No pen (no outline) |
+
+---
+
+## Canvas Options
+
+Options are passed as a semicolon-separated string to `MakeOutputCanvas()`:
+
+| Option                           | Description                                                                               | Example                            |
+| -------------------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------- |
+| `HTML_INLINE_IMAGES=on`          | Embed images as Base64 in HTML output                                                     | `"HTML_INLINE_IMAGES=on"`          |
+| `GRAPHIC_DPI=N`                  | Set output DPI for image rendering                                                        | `"GRAPHIC_DPI=300"`                |
+| `GRAPHIC_WIDTH=N`                | Set output width in pixels                                                                | `"GRAPHIC_WIDTH=4000"`             |
+| `OCR_INLINE_IMAGES=on`           | Enable OCR on inline images                                                               | `"OCR_INLINE_IMAGES=on"`           |
+| `DOCUMENT_HEADERS=ON`            | Include document headers in output                                                        | `"DOCUMENT_HEADERS=ON"`            |
+| `DOCUMENT_FOOTERS=ON`            | Include document footers in output                                                        | `"DOCUMENT_FOOTERS=ON"`            |
+| `TEXT_INLINE_LINKS=on`           | Include hyperlinks in text output                                                         | `"TEXT_INLINE_LINKS=on"`           |
+| `JSON_INCLUDE_WORD_LOCATIONS=on` | Include word locations in MDAST JSON                                                      | `"JSON_INCLUDE_WORD_LOCATIONS=on"` |
+| `MARKDOWN_INCLUDE_METADATA=ON`   | Embed document metadata (author, title, etc.) in Markdown output                         | `"MARKDOWN_INCLUDE_METADATA=ON"`   |
+| `MARKDOWN_METADATA_FORMAT=X`     | Format for embedded metadata: `JSON`, `YAML`, `COMMENTS`, or `None` (suppresses metadata) | `"MARKDOWN_METADATA_FORMAT=YAML"`  |
+
+Multiple options can be combined: `"HTML_INLINE_IMAGES=on;GRAPHIC_DPI=300"`
+
+---
+
+## Environment Variables
+
+| Variable         | Description                                            | Example                    |
+| ---------------- | ------------------------------------------------------ | -------------------------- |
+| `DF_LICENSE_KEY` | Document Filters license key                           | `HXM72 RG6U7 MTU65 ...`    |
+| `DF_PATH`        | Override path to native runtime binaries               | `/opt/docfilters/lib`      |
+| `ISYS_FONTS`     | Path to font assets directory                          | `./runtimes/26.1.0/assets` |
+| `ISYS_ASSETS`    | Path to asset directory (typically same as ISYS_FONTS) | `./runtimes/26.1.0/assets` |
+
+---
+
+## Input Sources
+
+The `GetExtractor()` method accepts:
+
+| Input Type        | Description                           |
+| ----------------- | ------------------------------------- |
+| `str` (file path) | Path to a file on disk                |
+| `bytes`           | Raw file content in memory            |
+| `BinaryIO`        | File-like object (e.g., `io.BytesIO`) |
+
+---
+
+## Supported Platforms
+
+### Runtime Binaries
+
+| OS      | Architecture          | Artifact                      |
+| ------- | --------------------- | ----------------------------- |
+| Windows | x64                   | `windows-intel-msvc-64`       |
+| Windows | x86                   | `windows-intel-msvc-32`       |
+| Linux   | x64 (glibc)           | `linux-intel-gcc-64`          |
+| Linux   | x64 (musl/Alpine)     | `linux-intel-clang-musl-64`   |
+| Linux   | ARM64 (glibc)         | `linux-aarch64-gcc-64`        |
+| Linux   | ARM64 (musl/Alpine)   | `linux-aarch64-clang-musl-64` |
+| Linux   | ARMv7                 | `linux-armv7l-gcc-32`         |
+| Linux   | PPC64LE               | `linux-ppc64le-gcc-64`        |
+| macOS   | Apple Silicon (ARM64) | `macos-arm64-clang-64`        |
+| macOS   | Intel (x64)           | `macos-intel-clang-64`        |
+| FreeBSD | x86                   | `freebsd-intel-clang-32`      |
+| FreeBSD | x64                   | `freebsd-intel-clang-64`      |
+
+### Supported File Formats (600+)
+
+Major categories include:
+
+- **Office**: Microsoft Word, Excel, PowerPoint (all versions), OpenDocument (ODT, ODS, ODP)
+- **PDF**: PDF, PDF/A
+- **Email**: EML, MSG, PST, OST, OLM, MBOX
+- **Archives**: ZIP, RAR, 7Z, TAR, GZIP
+- **Images**: JPEG, PNG, TIFF, BMP, GIF, SVG, WEBP, DICOM, HEIC
+- **Web**: HTML, XML, XHTML
+- **Text**: TXT, CSV, RTF, Markdown
+- **CAD**: DWG, DXF
+- **And many more** — see [full format list](https://hyland.github.io/DocumentFilters-Docs/latest/supported_platforms.html)
+
+---
+
+## Best Practices & Pitfalls
+
+| Practice                                   | Detail                                                                                                                                |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Initialize once, reuse**                 | Call `api.Initialize()` once at application startup and reuse the `api` instance. It is not thread-safe to initialize multiple times. |
+| **Always use context managers**            | Use `with api.GetExtractor(...)` and `with api.MakeOutputCanvas(...)` to ensure proper resource cleanup.                              |
+| **Set `ISYS_FONTS` and `ISYS_ASSETS`**     | Rendering without fonts produces poor output. Always download and configure the assets directory.                                     |
+| **Native binaries must match platform**    | The Python bindings are pure Python but call native C libraries. Always download the correct platform artifact.                       |
+| **License required for HD HTML**           | High-fidelity HTML5 output requires a valid license. Evaluation mode falls back to PDF/image output only.                             |
+| **License required for comparison**        | Document comparison is a licensed feature.                                                                                            |
+| **Handle `IGRException`**                  | Catch errors from Document Filters operations. Error code `4015` (in `e.args[0]['errorCode']`) indicates a license limitation. Use `extractor.PasswordCallback = lambda id: 'secret'` before `Open()` for password-protected files; without it, protected files raise an unhandled `IGRException`. |
+| **Pass `IGR_FORMAT_IMAGE` for rendering**  | When using `Pages` or `Canvas`, open with `IGR_BODY_AND_META \| IGR_FORMAT_IMAGE`.                                                    |
+| **Large files need memory**                | Rendering large documents loads pages into memory. Process page-by-page when possible.                                                |
+| **Runtime path is platform-specific**      | The `dll_path` must point to the directory containing `ISYS11df.dll` (Windows) or `libISYS11df.so` (Linux).                           |
+| **Cache runtime downloads**                | Native binaries are ~50-60 MB per platform. Cache them to avoid re-downloading.                                                       |
+| **Use `HTML_INLINE_IMAGES=on`**            | For self-contained HTML output without external image files.                                                                          |
+| **Strip overlay divs for selectable text** | Generated HTML may contain `idf-page-overlay` divs that block text selection — remove them in post-processing.                        |
+
+---
+
+## Error Handling
+
+### IGRException
+
+All SDK errors raise `IGRException` (exported at module level). Wrap extractor operations in `try/except`:
+
+```python
+from DocumentFilters import DocumentFilters, IGRException, IGR_BODY_AND_META
+
+try:
+    with api.GetExtractor("document.pdf") as extractor:
+        extractor.Open(IGR_BODY_AND_META)
+        # ...
+except IGRException as e:
+    error_code = e.args[0].get('errorCode') if e.args else None
+    if error_code == 4015:
+        print("License limitation — feature not available in evaluation mode")
+    else:
+        raise
+```
+
+### Password-Protected Files
+
+Set `extractor.PasswordCallback` before calling `Open()`. The callback receives a document ID and must return the password string (or `None` to abort):
+
+```python
+with api.GetExtractor("protected.pdf") as extractor:
+    extractor.PasswordCallback = lambda doc_id: "secret"
+    extractor.Open(IGR_BODY_AND_META)
+    # ...
+```
+
+Without a password callback, any password-protected document raises an unhandled `IGRException` in automated pipelines.
+
+---
+
+## Code Examples
+
+### Python: Initialize Document Filters
+
+```python
+import os
+from DocumentFilters import DocumentFilters
+
+def initialize_document_filters(license_key: str = "", runtime_path: str = "./runtimes") -> DocumentFilters:
+    """Initialize Document Filters with license and runtime binaries."""
+    api = DocumentFilters()
+
+    # Set font/asset paths
+    assets_path = os.path.join(runtime_path, "assets")
+    os.environ['ISYS_FONTS'] = assets_path
+    os.environ['ISYS_ASSETS'] = assets_path
+
+    # Initialize (empty string for evaluation mode)
+    api.Initialize(license_key, ".", runtime_path)
+    return api
+```
+
+### Python: Identify File Type
+
+```python
+from DocumentFilters import DocumentFilters, IGR_FORMAT_LONG_NAME
+
+def identify_file(api: DocumentFilters, file_path: str) -> dict:
+    """Identify a file's type and capabilities."""
+    with api.GetExtractor(file_path) as extractor:
+        return {
+            "type_id": extractor.getFileType(),
+            "type_name": extractor.getFileType(IGR_FORMAT_LONG_NAME),
+            "supports_text": extractor.getSupportsText(),
+            "supports_subfiles": extractor.getSupportsSubFiles(),
+        }
+```
+
+### Python: Extract Text
+
+```python
+from DocumentFilters import DocumentFilters, IGR_BODY_AND_META
+
+def extract_text(api: DocumentFilters, file_path: str) -> str:
+    """Extract all text from a document."""
+    text = []
+    with api.GetExtractor(file_path) as extractor:
+        if not extractor.getSupportsText():
+            return ""
+        extractor.Open(IGR_BODY_AND_META)
+        while not extractor.getEOF():
+            text.append(extractor.GetText(4096, stripControlCodes=True))
+    return "".join(text)
+```
+
+### Python: Convert to HTML5
+
+```python
+import os
+from DocumentFilters import (
+    DocumentFilters, IGR_BODY_AND_META, IGR_FORMAT_IMAGE, IGR_DEVICE_HTML
+)
+
+def convert_to_html(api: DocumentFilters, input_path: str, output_path: str) -> bool:
+    """Convert a document to high-fidelity HTML5."""
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    with api.GetExtractor(input_path) as extractor:
+        extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_HTML, "HTML_INLINE_IMAGES=on") as canvas:
+            for page in extractor.Pages:
+                canvas.RenderPage(page)
+
+    return os.path.exists(output_path)
+```
+
+### Python: Convert to PDF
+
+```python
+from DocumentFilters import (
+    DocumentFilters, IGR_BODY_AND_META, IGR_FORMAT_IMAGE, IGR_DEVICE_IMAGE_PDF
+)
+
+def convert_to_pdf(api: DocumentFilters, input_path: str, output_path: str) -> None:
+    """Convert a document to PDF."""
+    with api.GetExtractor(input_path) as extractor:
+        extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PDF, "") as canvas:
+            for page in extractor.Pages:
+                canvas.RenderPage(page)
+```
+
+### Python: Render Pages as PNG
+
+```python
+from DocumentFilters import (
+    DocumentFilters, IGR_BODY_AND_META, IGR_FORMAT_IMAGE, IGR_DEVICE_IMAGE_PNG
+)
+
+def render_pages_as_png(api: DocumentFilters, input_path: str, output_dir: str) -> list:
+    """Render each page as a PNG image."""
+    pages = []
+    with api.GetExtractor(input_path) as extractor:
+        extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+        for i, page in enumerate(extractor.Pages):
+            output_path = f"{output_dir}/page_{i + 1}.png"
+            with api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PNG, "") as canvas:
+                canvas.RenderPage(page)
+            pages.append(output_path)
+
+    return pages
+```
+
+### Python: Compare Documents
+
+```python
+from DocumentFilters import (
+    DocumentFilters, DocumentFilters as DF,
+    IGR_BODY_AND_META, IGR_FORMAT_IMAGE,
+    IGR_COMPARE_DOCUMENTS_COMPARE_WORDS,
+    IGR_COMPARE_DOCUMENTS_DIFFERENCE_EQUAL,
+    IGR_COMPARE_DOCUMENTS_DIFFERENCE_NEXT_BATCH,
+    IGR_COMPARE_DOCUMENTS_DIFFERENCE_INSERT,
+    IGR_COMPARE_DOCUMENTS_DIFFERENCE_DELETE,
+    IGR_COMPARE_DOCUMENTS_DIFFERENCE_FORMATTING,
+)
+
+def compare_documents(api: DocumentFilters, original: str, revised: str, options: dict = None) -> list:
+    """Compare two documents and return list of differences."""
+    compare_settings = DocumentFilters.CompareSettings()
+    compare_settings.CompareType = IGR_COMPARE_DOCUMENTS_COMPARE_WORDS
+    compare_settings.Flags = 0
+
+    options = options or {}
+    # Apply optional comparison flags from options dict
+    # e.g., options={"ignore_case": True, "ignore_headers": True}
+
+    differences = []
+
+    with api.GetExtractor(original) as left:
+        left.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+        with api.GetExtractor(revised) as right:
+            right.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE)
+
+            with left.Compare(otherDocument=right, compareSettings=compare_settings) as results:
+                while results.MoveNext():
+                    diff = results.Current
+
+                    if diff.Type in (IGR_COMPARE_DOCUMENTS_DIFFERENCE_EQUAL,
+                                     IGR_COMPARE_DOCUMENTS_DIFFERENCE_NEXT_BATCH):
+                        continue
+
+                    diff_type = "Unknown"
+                    if diff.Type == IGR_COMPARE_DOCUMENTS_DIFFERENCE_INSERT:
+                        diff_type = "Insert"
+                    elif diff.Type == IGR_COMPARE_DOCUMENTS_DIFFERENCE_DELETE:
+                        diff_type = "Delete"
+                    elif diff.Type == IGR_COMPARE_DOCUMENTS_DIFFERENCE_FORMATTING:
+                        diff_type = "Formatting"
+
+                    parts = []
+                    for hit in diff.Details:
+                        parts.append({
+                            "text": hit.Text,
+                            "page": hit.PageIndex + 1,
+                            "bounds": {
+                                "l": hit.Bounds.left,
+                                "t": hit.Bounds.top,
+                                "r": hit.Bounds.right,
+                                "b": hit.Bounds.bottom,
+                            }
+                        })
+
+                    differences.append({
+                        "type": diff_type,
+                        "originalPage": diff.OriginalPageIndex + 1,
+                        "revisedPage": diff.RevisedPageIndex + 1,
+                        "text": diff.GetText(),
+                        "parts": parts,
+                    })
+
+    return differences
+```
+
+### Python: Process from Memory (bytes/stream)
+
+```python
+import io
+from DocumentFilters import DocumentFilters, IGR_BODY_AND_META
+
+def extract_text_from_bytes(api: DocumentFilters, file_bytes: bytes) -> str:
+    """Extract text from document bytes (e.g., from a web upload)."""
+    text = []
+    with api.GetExtractor(file_bytes) as extractor:
+        extractor.Open(IGR_BODY_AND_META)
+        while not extractor.getEOF():
+            text.append(extractor.GetText(4096, stripControlCodes=True))
+    return "".join(text)
+
+def extract_text_from_stream(api: DocumentFilters, stream: io.BytesIO) -> str:
+    """Extract text from a file-like stream."""
+    text = []
+    with api.GetExtractor(stream) as extractor:
+        extractor.Open(IGR_BODY_AND_META)
+        while not extractor.getEOF():
+            text.append(extractor.GetText(4096, stripControlCodes=True))
+    return "".join(text)
+```
+
+### Python: Auto-Download Runtime & Assets
+
+```python
+import os
+import platform
+import sys
+import zipfile
+import urllib.request
+
+DF_VERSION = "26.1.0"
+
+def download_runtime(version: str = DF_VERSION) -> str:
+    """Download platform-specific runtime binaries."""
+    current_os = platform.system().lower()
+    machine = platform.machine().lower()
+
+    if current_os == "windows" and machine in ("amd64", "x86_64"):
+        artifact = "windows-intel-msvc-64"
+    elif current_os == "linux" and machine == "x86_64":
+        artifact = "linux-intel-gcc-64"
+    elif current_os == "darwin" and machine == "arm64":
+        artifact = "macos-arm64-clang-64"
+    elif current_os == "darwin" and machine == "x86_64":
+        artifact = "macos-intel-clang-64"
+    else:
+        raise RuntimeError(f"Unsupported platform: {current_os}-{machine}")
+
+    dest_dir = f"runtimes/{version}/{artifact}"
+    if not os.path.exists(dest_dir):
+        url = f"https://github.com/Hyland/DocumentFilters/releases/download/v{version}/{artifact}.zip"
+        archive = f"runtimes/{version}/{artifact}.zip"
+        os.makedirs(os.path.dirname(archive), exist_ok=True)
+        urllib.request.urlretrieve(url, archive)
+        os.makedirs(dest_dir, exist_ok=True)
+        with zipfile.ZipFile(archive, 'r') as z:
+            z.extractall(dest_dir)
+
+    return dest_dir
+
+def download_assets(version: str = DF_VERSION) -> str:
+    """Download font assets."""
+    dest_dir = f"runtimes/{version}/assets"
+    if not os.path.exists(dest_dir):
+        url = f"https://github.com/Hyland/DocumentFilters/releases/download/v{version}/assets.zip"
+        archive = f"runtimes/{version}/assets.zip"
+        os.makedirs(os.path.dirname(archive), exist_ok=True)
+        urllib.request.urlretrieve(url, archive)
+        os.makedirs(dest_dir, exist_ok=True)
+        with zipfile.ZipFile(archive, 'r') as z:
+            z.extractall(dest_dir)
+
+    return dest_dir
+```
+
+---
+
+## Troubleshooting
+
+### Initialization Errors
+
+| Error                                                    | Cause                                        | Solution                                                           |
+| -------------------------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------ |
+| `ModuleNotFoundError: No module named 'DocumentFilters'` | Python bindings not installed                | Run `pip install -r requirements.txt`                              |
+| `libISYS11df.so: cannot open shared object file`         | Native libraries not found                   | Set `LD_LIBRARY_PATH` or pass correct `dll_path` to `Initialize()` |
+| `ISYS11df.dll not found`                                 | Windows native libraries not found           | Ensure runtime binaries are downloaded and path is correct         |
+| `Failed to initialize DocumentFilters`                   | Runtime path incorrect or binaries corrupted | Re-download binaries; verify platform matches                      |
+
+### Licensing Errors
+
+| Error                                       | Cause                                       | Solution                                                            |
+| ------------------------------------------- | ------------------------------------------- | ------------------------------------------------------------------- |
+| Error code `4015`                           | License limitation reached                  | Provide a valid license key or stay within evaluation limits        |
+| `limited evaluation` in error message       | Trying to use licensed features without key | Obtain a license key from Hyland                                    |
+| HTML output has "Evaluation Copy" watermark | No license key provided                     | Set `DF_LICENSE_KEY` in `.env` file                                 |
+| Comparison fails with `PermissionError`     | Comparison requires a valid license         | Provide license key; comparison is not available in evaluation mode |
+
+### Rendering Issues
+
+| Issue                                 | Cause                                    | Solution                                                                   |
+| ------------------------------------- | ---------------------------------------- | -------------------------------------------------------------------------- |
+| Missing or garbled fonts in output    | Font assets not configured               | Download assets and set `ISYS_FONTS` / `ISYS_ASSETS` environment variables |
+| Blank pages in PNG output             | File type or page issue                  | Check that `IGR_FORMAT_IMAGE` is set when opening                          |
+| Overlay blocks text selection in HTML | `idf-page-overlay` div in generated HTML | Strip overlay divs in post-processing                                      |
+| Large HTML file size                  | Images not inlined efficiently           | Use `HTML_INLINE_IMAGES=on` for self-contained output                      |
+
+### Comparison Issues
+
+| Issue                            | Cause                           | Solution                                                             |
+| -------------------------------- | ------------------------------- | -------------------------------------------------------------------- |
+| Empty comparison results         | Documents are identical         | Expected behavior — no differences to report                         |
+| `GetText()` returns empty string | Some diff types don't have text | Handle gracefully with try/except                                    |
+| Bounding boxes seem offset       | Page index is 0-based           | Add 1 to `PageIndex` for display; coordinates are in document points |
+
+### Platform Issues
+
+| Issue                               | Cause                       | Solution                                                            |
+| ----------------------------------- | --------------------------- | ------------------------------------------------------------------- |
+| Download fails for runtime binaries | Network or URL issue        | Verify GitHub access; check that version tag exists in releases     |
+| Wrong binary architecture           | Platform detection mismatch | Override with `DF_PATH` environment variable                        |
+| Slow processing                     | Large or complex files      | Expected for some formats; process pages individually               |
+| Python 3.13 iterator error          | SDK compatibility           | Update to Document Filters v26.1.0+ which fixes Python 3.13 support |
+
+### HTTP Status Codes (Python Samples Download)
+
+| Code  | Meaning                                                                 |
+| ----- | ----------------------------------------------------------------------- |
+| `200` | Download successful                                                     |
+| `404` | Version or artifact not found — check the version tag and artifact name |
+| `403` | Repository access denied — ensure GitHub access is available            |

--- a/skills/extract-document-metadata/skill.md
+++ b/skills/extract-document-metadata/skill.md
@@ -1,0 +1,140 @@
+---
+name: extract-document-metadata
+description: Get file type, page count, and document properties from any document using Document Filters
+---
+
+# Extract Document Metadata
+
+Hyland Document Filters identifies the file type and extracts properties — format name, MIME type, page count, and content fingerprints — from over 600 formats in a single local call, with no conversion server required and no documents leaving the machine. In an AI document pipeline, this lets you route files by type, skip already-indexed documents using MD5/SHA1 deduplication, and gate expensive LLM calls on page count before they start.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+## Python
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def get_metadata(filename, password=None):
+    with api.GetExtractor(filename) as doc:
+        # Set a password callback for protected files (preferred over passing PASSWORD= in options string)
+        if password:
+            doc.PasswordCallback = lambda fname: password
+        # Or derive at runtime: doc.PasswordCallback = lambda fname: os.environ.get("DOC_PASSWORD", "")
+
+        file_type_id = doc.getFileType()
+        file_type_name = doc.getFileType(IGR_FORMAT_LONG_NAME)  # None if format unrecognised
+        supports_text = doc.getSupportsText()
+        supports_subfiles = doc.getSupportsSubFiles()
+        supports_html = doc.getSupportsHTML()
+        hash_md5 = doc.getHashMD5()
+        hash_sha1 = doc.getHashSHA1()
+
+        # Open with IGR_BODY_AND_META (enables metadata) | IGR_FORMAT_IMAGE (enables GetPageCount).
+        # Omitting Open() lets GetPageCount() auto-open in image-only mode, but metadata properties
+        # (capabilities, file type from handle) will not reflect the opened state.
+        try:
+            doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+            page_count = doc.GetPageCount()
+        except IGRException as e:
+            code = e.args[0].get("errorCode") if e.args else None
+            if code == IGR_E_PASSWORD:
+                raise ValueError(f"File is password-protected: {filename}") from e
+            if code == IGR_E_NOT_FOUND:
+                raise FileNotFoundError(filename) from e
+            if code == IGR_E_FILE_CORRUPT:
+                raise ValueError(f"File is corrupt or truncated: {filename}") from e
+            raise
+
+        return {
+            "file_type_id": file_type_id,
+            "file_type_name": file_type_name,
+            "supports_text": supports_text,
+            "supports_subfiles": supports_subfiles,
+            "supports_html": supports_html,
+            "hash_md5": hash_md5,
+            "hash_sha1": hash_sha1,
+            "page_count": page_count,
+        }
+
+info = get_metadata("report.docx")
+print(info)
+# {'file_type_id': 289, 'file_type_name': 'Microsoft Word 2007',
+#  'supports_text': True, 'supports_subfiles': False, 'supports_html': True,
+#  'hash_md5': 'a1b2c3...', 'hash_sha1': 'd4e5f6...', 'page_count': 12}
+```
+
+## Notes
+
+- Calling `doc.getFileType()` with no argument returns the numeric type ID. Pass one of the format-query constants for a string form:
+
+  | Constant              | Value | Returns                          |
+  |-----------------------|-------|----------------------------------|
+  | `IGR_FORMAT_LONG_NAME`  | 0     | Human-readable name              |
+  | `IGR_FORMAT_SHORT_NAME` | 1     | Short/abbreviated name           |
+  | `IGR_FORMAT_CONFIG_NAME`| 2     | Internal config name             |
+  | `IGR_FORMAT_CLASS_NAME` | 3     | Class name                       |
+  | `IGR_FORMAT_MIME_TYPE`  | 5     | MIME type string                 |
+  | `IGR_FORMAT_CATEGORY`   | 6     | Category string                  |
+
+- If `file_type_id == 0` or `file_type_name` is `None`, the format was not recognised. Check the file before further processing rather than assuming all results are valid. Use these two guards at the top of any processing loop:
+
+  ```python
+  if info['file_type_id'] == 0:
+      pass  # skip — unrecognised format
+  if not info['supports_text']:
+      pass  # skip — no extractable text (e.g. pure image PDF, binary file)
+  ```
+- For non-paginated formats (plain text, CSV, XML), `GetPageCount()` typically returns 0 or 1 — use character-count-based chunking rather than page-based chunking in these cases.
+- For metadata-only queries (no page count), open with `doc.Open(IGR_BODY_AND_META, "")` to avoid the heavier render-mode open.
+- For password-protected files, the `PasswordCallback` property is the preferred approach when the password is not known until runtime or when processing many files with different passwords: `doc.PasswordCallback = lambda fname: os.environ.get("DOC_PASSWORD", "")`. You can also pass it inline: `doc.Open(IGR_BODY_AND_META, "PASSWORD=secret")`.
+- `getSupportsSubFiles()` is `True` for archives, email containers, and compound documents
+- `getSupportsHTML()` returns `True` if the format supports conversion to HD HTML
+- To check multiple capabilities at once, call `doc.GetFileCapabilities()` and test against `IGR_FILE_SUPPORTS_TEXT`, `IGR_FILE_SUPPORTS_SUBFILES`, and `IGR_FILE_SUPPORTS_HDHTML` bitmask constants. This is useful for building a routing table in batch pipelines.
+- `getHashMD5()` and `getHashSHA1()` return content fingerprints and are available before or after `Open()`
+- **Process for AI:** For LLM/AI pipelines, consider using the `convert-to-markdown` skill (`IGR_FORMAT_MARKDOWN`) instead of reading raw text. Markdown conversion preserves heading structure, tables, and document flow far better than plain text extraction, making it the preferred approach when the downstream consumer is an LLM.
+
+## Real-world example: batch pipeline pre-filter
+
+Gate expensive LLM processing with three cheap checks — format recognition, deduplication, and page count — before queuing any file.
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+seen_md5 = set()   # populated from your index DB at startup
+llm_queue = []
+
+for filepath in file_list:
+    info = get_metadata(filepath)
+
+    if info["file_type_id"] == 0:
+        continue  # unrecognised format — skip
+
+    if info["hash_md5"] in seen_md5:
+        continue  # already indexed — skip
+
+    if info["page_count"] > 50:
+        continue  # too large for LLM context — skip or route to chunker
+
+    seen_md5.add(info["hash_md5"])
+    llm_queue.append({"path": filepath, "type": info["file_type_name"]})
+```
+
+Three guard clauses eliminate the bulk of unprocessable or redundant files before any I/O-heavy conversion or LLM call occurs.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/extract-document-structure/skill.md
+++ b/skills/extract-document-structure/skill.md
@@ -1,0 +1,293 @@
+---
+name: extract-document-structure
+description: Extract structured document content as Markdown or JSON using Document Filters, preserving headings, tables, paragraphs, and word-level bounding boxes
+---
+
+# Extract Document Structure
+
+Hyland Document Filters extracts clean, structured content from any document — PDFs, Word files, spreadsheets, email, and 600+ other formats — running locally with no servers required. Feed any document — including old PDFs, scanned invoices, or legacy Word files — into an AI pipeline and get clean, structured text back in seconds. This makes it well-suited for document AI pipelines where you need accurate, private, high-throughput extraction at scale.
+
+It can extract the logical structure of a document in two complementary forms:
+
+- **Markdown** — headings, tables, lists, and paragraphs as readable text; ideal for LLM ingestion
+- **JSON** — paragraphs, runs, words, bounding boxes, fonts, and styles as machine-readable data; ideal for form parsing, spatial queries, and document understanding pipelines
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+Document Filters supports 600+ formats including PDF, Word, Excel, PowerPoint, email (MSG/EML), HTML, and many legacy formats — no per-format plugins required.
+
+## Extract as Markdown
+
+Markdown preserves document structure as readable text. Use `MARKDOWN_FLAVOR=GPT` for cleaner LLM ingestion.
+
+```python
+import os, io
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def to_markdown(input_path, output_path=None, doc_opts="", canvas_opts=""):
+    """
+    Convert any document to Markdown.
+    Always returns the Markdown string; when output_path is given, the file is
+    also written to disk (no extra file-read — the string is captured in memory
+    via BytesIO and written separately when an output path is provided).
+    Note: returns an empty string for image-only or unsupported formats; use
+    OCR pre-processing for scanned PDFs.
+    """
+    buf = io.BytesIO()
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, doc_opts)
+        if not doc.getSupportsText():
+            return ""  # image-only or unsupported format — OCR needed for scanned PDFs
+        with api.MakeOutputCanvas(buf, IGR_DEVICE_MARKDOWN, canvas_opts) as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+    content = buf.getvalue().decode("utf-8")
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as f:
+            f.write(content)
+    return content
+
+# Basic — preserves headings, tables, lists
+md = to_markdown("report.docx")
+
+# Optimised for LLM ingestion — disable image embedding (default on) to avoid
+# large base64 blobs in the prompt; enable metadata for provenance tracking
+md = to_markdown(
+    "report.pdf",
+    doc_opts="PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on;PDF_LIST_DETECTION=on",
+    canvas_opts="MARKDOWN_FLAVOR=GPT;MARKDOWN_INCLUDE_IMAGES=off;MARKDOWN_INCLUDE_METADATA=on;MARKDOWN_METADATA_FORMAT=YAML",
+)
+
+# Full fidelity — include images, charts, headers/footers
+md = to_markdown(
+    "slides.pptx",
+    canvas_opts="MARKDOWN_INCLUDE_IMAGES=on;MARKDOWN_INCLUDE_CHARTS=on;MARKDOWN_INCLUDE_CHART_TABLE=on",
+)
+```
+
+### Markdown Options
+
+PDF input options are **document-level** (pass to `doc.Open()`). Markdown options are **canvas-level** (pass to `MakeOutputCanvas()`).
+
+#### PDF Input (document-level)
+
+| Option                     | Values      | Default | Notes                                                     |
+|----------------------------|-------------|---------|-----------------------------------------------------------|
+| `PDF_LAYOUT_DETECTION`     | `on`, `off` | `off`   | Master switch for structure detection in PDFs             |
+| `PDF_TABLE_DETECTION`      | `on`, `off` | `off`   | Reconstruct tables; requires `PDF_LAYOUT_DETECTION=on`    |
+| `PDF_LIST_DETECTION`       | `on`, `off` | `off`   | Detect lists; requires `PDF_LAYOUT_DETECTION=on`          |
+
+#### Markdown Output (canvas-level)
+
+| Option                           | Values                             | Default    | Notes                              |
+|----------------------------------|------------------------------------|------------|------------------------------------|
+| `PDF_MARKDOWN_UNWRAP_TEXT`       | `on`, `off`                        | `off`      | (PDF only) Unwrap hard-wrapped lines in PDFs for cleaner prose |
+| `MARKDOWN_FLAVOR`                | `GFM`, `GPT`                       | `GFM`      | `GPT` optimises output for LLMs    |
+| `MARKDOWN_INCLUDE_LOCATIONS`     | `on`, `off`                        | `off`      | Inject `<!-- LOC: page, (l,t,r,b) -->` before each paragraph — links text back to its page and bounding box |
+| `MARKDOWN_INCLUDE_METADATA`      | `on`, `off`                        | `off`      | Prepend document metadata block    |
+| `MARKDOWN_METADATA_FORMAT`       | `YAML`, `TOML`, `JSON`, `COMMENTS` | `COMMENTS` | Format of the metadata block       |
+| `MARKDOWN_SIMPLE_TABLE_STYLE`    | `PIPE`, `GRID`, `HTML`, `PIPE_WITH_HTML` | `PIPE` |                               |
+| `MARKDOWN_COMPLEX_TABLE_STYLE`   | `PIPE`, `GRID`, `HTML`, `PIPE_WITH_HTML` | `HTML` | Merged/spanning cells; `PIPE_WITH_HTML` renders pipe-style with HTML for merged cells |
+| `MARKDOWN_INCLUDE_IMAGES`        | `on`, `off`                        | `on`       | Embed images as base64 data URIs   |
+| `MARKDOWN_INCLUDE_CHARTS`        | `on`, `off`                        | `off`      | Master switch for chart data       |
+| `MARKDOWN_INCLUDE_CHART_TABLE`   | `on`, `off`                        | `off`      | Chart data as Markdown table       |
+| `MARKDOWN_INCLUDE_HEADERS`       | `off`, `on`, `FIRST`               | `off`      | Page headers                       |
+| `MARKDOWN_INCLUDE_FOOTERS`       | `off`, `on`, `FIRST`               | `off`      | Page footers                       |
+| `MARKDOWN_INCLUDE_FOOTNOTES`     | `on`, `off`                        | `off`      | Footnotes and endnotes             |
+| `MARKDOWN_HR_BETWEEN_PAGES`      | `on`, `off`                        | `off`      | Insert `---` between pages         |
+| `MARKDOWN_HEADERS_STYLE`         | `ATX`, `SETEXT`                    | `ATX`      | ATX uses `#` prefixes; SETEXT uses underline style |
+
+## Location Data in Markdown
+
+`MARKDOWN_INCLUDE_LOCATIONS=on` injects an HTML comment before each paragraph with its page number and bounding box:
+
+```
+<!-- LOC: 1, (100,257,1284,683) -->
+# How Hyland Won Erie Insurance
+```
+
+The format is `<!-- LOC: page, (left,top,right,bottom) -->` in points (1/72 inch) from the top-left of the page.
+
+This is useful for **citation-aware RAG** — after retrieval, you can resolve each chunk back to its exact page and coordinates for highlighting or verification:
+
+```python
+import io, re, os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+LOC_RE = re.compile(r'<!-- LOC: (\d+), \((-?\d+),(-?\d+),(-?\d+),(-?\d+)\) -->')
+
+def to_markdown_with_locations(input_path):
+    """Return list of {page, bounds, text} dicts, one per paragraph."""
+    buf = io.BytesIO()
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        with api.MakeOutputCanvas(buf, IGR_DEVICE_MARKDOWN,
+                                  "MARKDOWN_INCLUDE_LOCATIONS=on;MARKDOWN_FLAVOR=GPT") as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+    md = buf.getvalue().decode("utf-8")
+
+    paragraphs = []
+    current_loc = None
+    for line in md.splitlines():
+        m = LOC_RE.match(line)
+        if m:
+            current_loc = {
+                "page": int(m.group(1)),
+                "bounds": (int(m.group(2)), int(m.group(3)), int(m.group(4)), int(m.group(5))),
+            }
+        elif current_loc and line.strip():
+            paragraphs.append({**current_loc, "text": line.strip()})
+            current_loc = None
+    return paragraphs
+
+paragraphs = to_markdown_with_locations("report.pdf")
+for p in paragraphs[:3]:
+    print(f"Page {p['page']} {p['bounds']}: {p['text'][:60]}")
+# Page 1 (100, 257, 1284, 683): # How Hyland Won Erie Insurance...
+```
+
+## Extract as JSON
+
+JSON output includes paragraphs, runs, font data, hyperlinks, and optionally word-level bounding boxes — useful for spatial queries, layout analysis, and form field extraction.
+
+```python
+import os, io, json
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def to_json(input_path, output_path=None, include_words=False, pretty=False):
+    """
+    Export document structure as JSON.
+    Returns the parsed dict (always in-memory via BytesIO).
+    When output_path is given, also writes the JSON file to disk.
+    Note: MakeOutputCanvas accepts either a file path or a stream — passing
+    io.BytesIO() keeps everything in memory, which is ideal for pipelines that
+    load documents from S3 or database blobs without touching the filesystem.
+    Note: returns an empty dict for image-only or unsupported formats; use
+    OCR pre-processing for scanned PDFs.
+    """
+    canvas_opts = (
+        f"JSON_FORMAT_OUTPUT={str(pretty).lower()};"
+        f"JSON_INCLUDE_WORDS={str(include_words).lower()};"
+        "JSON_SKIP_EMPTY_PARAGRAPHS=true;"
+    )
+    buf = io.BytesIO()
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        if not doc.getSupportsText():
+            return {}  # image-only or unsupported format — OCR needed for scanned PDFs
+        with api.MakeOutputCanvas(buf, IGR_DEVICE_JSON, canvas_opts) as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+    data = json.loads(buf.getvalue().decode("utf-8"))
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2 if pretty else None)
+    return data
+
+structure = to_json("report.pdf", pretty=True)
+structure_with_words = to_json("invoice.pdf", include_words=True)
+
+# In-memory only (e.g. document bytes loaded from S3 or a database blob):
+# buf = io.BytesIO(document_bytes)
+# structure = to_json(buf, include_words=True)
+```
+
+### JSON Canvas Options
+
+| Option                       | Values          | Default | Notes                                      |
+|------------------------------|-----------------|---------|--------------------------------------------|
+| `JSON_FORMAT_OUTPUT`         | `true`, `false` | `false` | Pretty-print with newlines and indentation |
+| `JSON_INCLUDE_WORDS`         | `true`, `false` | `false` | Include word-level bounding box data       |
+| `JSON_INCLUDE_WHITESPACE`    | `true`, `false` | `false` | Include whitespace-only word entries       |
+| `JSON_SKIP_EMPTY_PARAGRAPHS` | `true`, `false` | `false` | Omit paragraphs with no text content       |
+
+## Word-Level Bounding Boxes
+
+Access word coordinates directly via the page API — no need to go through the JSON device.
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def extract_words(path):
+    """Return all words with page coordinates (in points, 1/72 inch)."""
+    words = []
+    with api.GetExtractor(path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        for page_idx, page in enumerate(doc.Pages):
+            with page:
+                for word in page.Words:
+                    words.append({
+                        "page": page_idx + 1,
+                        "text": word.Text,
+                        "x": word.X,
+                        "y": word.Y,
+                        "width": word.Width,
+                        "height": word.Height,
+                    })
+    return words
+```
+
+## Page Statistics
+
+```python
+# Assumes api initialized as shown above
+def page_stats(path):
+    results = []
+    with api.GetExtractor(path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        for i, page in enumerate(doc.Pages):
+            with page as p:
+                results.append({
+                    "page": i + 1,
+                    "width_pts": p.Width,
+                    "height_pts": p.Height,
+                    "word_count": p.WordCount,
+                })
+    return results
+```
+
+## When to Use Each Format
+
+| Use case | Recommended format |
+|---|---|
+| LLM ingestion, RAG chunking, summarization | Markdown (`MARKDOWN_FLAVOR=GPT`, `MARKDOWN_INCLUDE_IMAGES=off`) |
+| Citation-aware RAG (resolve chunk back to page/coordinates) | Markdown with `MARKDOWN_INCLUDE_LOCATIONS=on` |
+| Table extraction from PDFs | Markdown with `PDF_TABLE_DETECTION=on` |
+| Form field extraction, layout analysis | JSON with `JSON_INCLUDE_WORDS=true` |
+| Spatial queries (find text in a region) | Word bounding boxes via `page.Words` |
+| Heading/style detection, classification | JSON (includes paragraph style and run-level font data) |
+
+## Notes
+
+- Word coordinates are in points (1/72 inch) from the top-left of the page; cast to `int()` when passing to `canvas.Rect()`
+- `page.Words` and `page.WordCount` require `IGR_FORMAT_IMAGE` to be included in the flags passed to `doc.Open()` — use `IGR_BODY_AND_META | IGR_FORMAT_IMAGE`
+- The JSON device includes hyperlinks and run-level font attributes (bold, italic, size, color) — useful for heading detection without style names
+- `doc.getSupportsText()` returns `False` for image-only PDFs and unsupported formats — both `to_markdown` and `to_json` guard on this; use an OCR pre-processing step (e.g. Tesseract) for scanned PDFs before passing to Document Filters
+- Eval mode limits output to the first few pages with a watermark; `IGR_DEVICE_JSON` (the JSON canvas) requires a valid license — JSON extraction will fail in evaluation mode. The Markdown canvas works in eval mode (with the page limit and watermark). Set `DF_LICENSE_KEY` for full access to all features.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/extract-text/skill.md
+++ b/skills/extract-text/skill.md
@@ -1,0 +1,144 @@
+---
+name: extract-text
+description: Extract plain text from any document supported by Document Filters (600+ formats)
+---
+
+# Extract Text from a Document
+
+Hyland Document Filters extracts clean, AI-ready text from 600+ file formats — Word, PDF, Excel, email, archives, and more — running entirely locally with no cloud dependency, so your RAG pipeline or LLM application can index any document your organization works with, without format-specific parsers or external services. It works equally well on-premises, in air-gapped environments, and in cloud pipelines.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+## Python
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # key ("" = eval/watermarked mode), resource_path for temp files
+
+def extract_text(filename):
+    with api.GetExtractor(filename) as doc:
+        if not doc.getSupportsText():
+            return ""
+        doc.Open(IGR_BODY_AND_META, "")
+        text = []
+        while not doc.getEOF():
+            text.append(doc.GetText(4096, stripControlCodes=True))
+        return "".join(text)
+
+print(extract_text("report.pdf"))
+```
+
+### Convenience: write directly to a file
+
+```python
+with api.GetExtractor("report.pdf") as doc:
+    doc.Open(IGR_BODY_AND_META, "")
+    doc.SaveTo("output.txt")
+    # Note: stripControlCodes has no effect when passing a file path (SDK bug: the parameter is
+    # dropped in the recursive call). To strip control codes, use either the explicit GetText loop
+    # shown above, or pass an open file object instead of a path string:
+    #
+    #   with open("output.txt", "w", encoding="utf-8") as f:
+    #       doc.SaveTo(f, stripControlCodes=True)
+```
+
+## Subfiles (archives, emails)
+
+```python
+def extract_text_recursive(doc):
+    text = []
+    # Always open explicitly before reading text or subfiles — avoids relying on
+    # implicit auto-open behavior that may not be obvious to readers of this code.
+    doc.Open(IGR_BODY_AND_META, "")
+    if doc.getSupportsText():
+        while not doc.getEOF():
+            text.append(doc.GetText(4096, stripControlCodes=True))
+    if doc.getSupportsSubFiles():
+        # Recursion handles arbitrary nesting depth: archives within archives,
+        # emails with zip attachments containing further documents, etc.
+        # This makes the function suitable for fully flattening email archives for RAG indexing.
+        for child in doc.SubFiles:
+            with child:
+                text.extend(extract_text_recursive(child))
+    return text
+
+with api.GetExtractor("archive.zip") as doc:
+    print("\n".join(extract_text_recursive(doc)))
+```
+
+## Page-level chunking (for AI/RAG)
+
+To chunk a document by page for embedding pipelines, open with `IGR_BODY_AND_META | IGR_FORMAT_IMAGE` and iterate over `doc.Pages`:
+
+```python
+with api.GetExtractor("report.pdf") as doc:
+    doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+    if not doc.getSupportsText():
+        print("No text layer — file may be image-only or a non-text format")
+    else:
+        for i, page in enumerate(doc.Pages):
+            text = page.GetText()
+            # page.GetText() may return an empty string for image-only pages
+            # (e.g. scanned PDFs without an OCR layer); check for this in production code
+            # embed or store text as a chunk for page i
+            print(f"--- Page {i + 1} ---\n{text}")
+```
+
+Each page also exposes `page.Words` (with bounding boxes) for coordinate-grounded citation or highlight workflows — see the `extract-document-structure` skill.
+
+## OCR (scanned PDFs and images)
+
+The OCR engine is primarily designed for image-based formats (TIFF, JPEG, BMP, PNG) and scanned PDFs with no embedded text layer. Using `OCR=ON` with `IGR_BODY_AND_META` on Office documents or PDFs with selectable text may duplicate or corrupt the extracted text; use `IGR_BODY_ONLY` for those cases.
+
+```python
+with api.GetExtractor("scan.pdf") as doc:
+    doc.Open(IGR_BODY_ONLY, "OCR=ON;OCR_REORIENT_PAGES=ON")
+    text = []
+    while not doc.getEOF():
+        text.append(doc.GetText(4096, stripControlCodes=True))
+    print("".join(text))
+```
+
+## Notes
+
+- `stripControlCodes=True` removes non-printable characters from the output
+- Eval mode limits extraction to the first few pages of each document
+- **Password-protected files:** `Open()` raises `IGRException` with `errorCode == IGR_E_PASSWORD` (5) if no callback is supplied. To provide a password programmatically, set the `PasswordCallback` property on the extractor before calling `Open()`:
+
+  ```python
+  with api.GetExtractor("protected.pdf") as doc:
+      doc.PasswordCallback = lambda doc_id: "secret"
+      doc.Open(IGR_BODY_AND_META, "")
+  ```
+
+- **Error handling:** `GetExtractor()` does not raise for missing files — the exception is raised in `Open()`. Common error codes:
+
+  | Code | Constant | Meaning |
+  |------|----------|---------|
+  | 1 | `IGR_E_OPEN_ERROR` | File could not be opened (access/permission denied) |
+  | 5 | `IGR_E_PASSWORD` | File is password-protected and no password was supplied |
+  | 10 | `IGR_E_NOT_FOUND` | File does not exist |
+  | 17 | `IGR_E_FILE_CORRUPT` | File is truncated or corrupt |
+  | 2 | `IGR_E_WRONG_TYPE` | Format detection failed |
+
+- **Markdown for AI/LLM pipelines:** For RAG or AI ingestion where document structure matters (headings, lists, tables), consider using a Markdown canvas (`IGR_DEVICE_MARKDOWN`) instead of `GetText()`, which preserves that structure. See the `convert-to-markdown` skill.
+
+- Useful `doc.Open()` option strings for text extraction:
+  - `"PDF_LAYOUT_DETECTION=ON;PDF_TABLE_DETECTION=ON"` — improves table extraction from PDFs
+  - `"PDF_WORD_WRAP_DETECTION=ON"` — improves word wrap handling in PDFs
+  - `"OCR=ON;OCR_REORIENT_PAGES=ON"` — enable OCR (use with `IGR_BODY_ONLY`)
+  - `"EXTRACT_EMBEDDED_CONTENT=ON"` — extracts text from embedded OLE/attachment objects
+  - `LOCALE` and `CHARSET_HINT` options can improve extraction accuracy for non-ASCII or legacy-encoded documents — particularly relevant for email archives and older Office formats targeting international content
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/install.ps1
+++ b/skills/install.ps1
@@ -1,0 +1,81 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('claude-code', 'cursor', 'copilot', 'all')]
+    [string]$Platform = 'all',
+    [string]$Skills = ''
+)
+
+$SkillsDir = $PSScriptRoot
+
+function Get-SkillList {
+    if ($Skills) {
+        return ($Skills -split ',') | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' }
+    }
+    Get-ChildItem -Path $SkillsDir -Directory |
+        Where-Object { Test-Path (Join-Path $_.FullName 'skill.md') } |
+        Select-Object -ExpandProperty Name
+}
+
+function Install-ClaudeCode($skill) {
+    $src = Join-Path $SkillsDir $skill
+    $dest = Join-Path $HOME ".claude\plugins\document-filters-$skill"
+    if (-not (Test-Path (Join-Path $src 'skill.md'))) {
+        Write-Host "  SKIP $skill (skill.md not found)"
+        return
+    }
+    New-Item -ItemType Directory -Force -Path $dest | Out-Null
+    Copy-Item "$src\*" $dest -Recurse -Force
+    Write-Host "  OK   claude-code: $dest"
+}
+
+function Install-Cursor($skill) {
+    $src = Join-Path $SkillsDir "$skill\skill.md"
+    $dest = Join-Path (Get-Location) '.cursorrules'
+    if (-not (Test-Path $src)) {
+        Write-Host "  SKIP $skill (skill.md not found)"
+        return
+    }
+    $marker = "<!-- document-filters-$skill -->"
+    $content = if (Test-Path $dest) { Get-Content $dest -Raw } else { '' }
+    # Remove existing block
+    $content = [regex]::Replace($content, '\n?' + [regex]::Escape($marker) + '[\s\S]*?' + [regex]::Escape($marker) + '\r?\n?', '')
+    $skillContent = Get-Content $src -Raw
+    $content += "`n$marker`n$skillContent`n$marker`n"
+    Set-Content $dest $content -NoNewline
+    Write-Host "  OK   cursor: $dest"
+}
+
+function Install-Copilot($skill) {
+    $src = Join-Path $SkillsDir "$skill\skill.md"
+    $githubDir = Join-Path (Get-Location) '.github'
+    $dest = Join-Path $githubDir 'copilot-instructions.md'
+    if (-not (Test-Path $src)) {
+        Write-Host "  SKIP $skill (skill.md not found)"
+        return
+    }
+    New-Item -ItemType Directory -Force -Path $githubDir | Out-Null
+    $marker = "<!-- document-filters-$skill -->"
+    $content = if (Test-Path $dest) { Get-Content $dest -Raw } else { '' }
+    $content = [regex]::Replace($content, '\n?' + [regex]::Escape($marker) + '[\s\S]*?' + [regex]::Escape($marker) + '\r?\n?', '')
+    $skillContent = Get-Content $src -Raw
+    $content += "`n$marker`n$skillContent`n$marker`n"
+    Set-Content $dest $content -NoNewline
+    Write-Host "  OK   copilot: $dest"
+}
+
+Write-Host "Installing Document Filters skills (platform: $Platform)"
+foreach ($skill in (Get-SkillList)) {
+    if (-not $skill) { continue }
+    Write-Host "[$skill]"
+    switch ($Platform) {
+        'claude-code' { Install-ClaudeCode $skill }
+        'cursor'      { Install-Cursor $skill }
+        'copilot'     { Install-Copilot $skill }
+        'all' {
+            Install-ClaudeCode $skill
+            Install-Cursor $skill
+            Install-Copilot $skill
+        }
+    }
+}
+Write-Host "Done."

--- a/skills/install.sh
+++ b/skills/install.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SKILLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLATFORM="all"
+SELECTED_SKILLS=""
+
+usage() {
+    echo "Usage: $0 [--platform claude-code|cursor|copilot|all] [--skills skill1,skill2]"
+    exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --platform) PLATFORM="$2"; shift 2 ;;
+        --skills)   SELECTED_SKILLS="$2"; shift 2 ;;
+        -h|--help)  echo "Usage: $0 [--platform claude-code|cursor|copilot|all] [--skills skill1,skill2]"; exit 0 ;;
+        *) echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+# Build list of skill folders to install
+get_skills() {
+    if [[ -n "$SELECTED_SKILLS" ]]; then
+        echo "$SELECTED_SKILLS" | tr ',' '\n'
+    else
+        for d in "$SKILLS_DIR"/*/; do
+            [ -f "$d/skill.md" ] && basename "$d"
+        done
+    fi
+}
+
+install_claude_code() {
+    local skill="$1"
+    local src="$SKILLS_DIR/$skill"
+    local dest="$HOME/.claude/plugins/document-filters-$skill"
+    if [ ! -f "$src/skill.md" ]; then
+        echo "  SKIP $skill (skill.md not found)"
+        return
+    fi
+    mkdir -p "$dest"
+    cp -r "$src/." "$dest/"
+    echo "  OK   claude-code: $dest"
+}
+
+install_cursor() {
+    local skill="$1"
+    local src="$SKILLS_DIR/$skill/skill.md"
+    local dest=".cursorrules"
+    if [ ! -f "$src" ]; then
+        echo "  SKIP $skill (skill.md not found)"
+        return
+    fi
+    # Idempotent: remove old block then re-append
+    local marker="<!-- document-filters-$skill -->"
+    if [ -f "$dest" ]; then
+        # Remove existing block for this skill
+        perl -i'' -0pe "s/\Q$marker\E.*?\Q$marker\E\n?//s" "$dest" 2>/dev/null || true
+    fi
+    printf "\n%s\n" "$marker" >> "$dest"
+    cat "$src" >> "$dest"
+    printf "\n%s\n" "$marker" >> "$dest"
+    echo "  OK   cursor: $dest"
+}
+
+install_copilot() {
+    local skill="$1"
+    local src="$SKILLS_DIR/$skill/skill.md"
+    local dest=".github/copilot-instructions.md"
+    if [ ! -f "$src" ]; then
+        echo "  SKIP $skill (skill.md not found)"
+        return
+    fi
+    mkdir -p .github
+    local marker="<!-- document-filters-$skill -->"
+    if [ -f "$dest" ]; then
+        perl -i'' -0pe "s/\Q$marker\E.*?\Q$marker\E\n?//s" "$dest" 2>/dev/null || true
+    fi
+    printf "\n%s\n" "$marker" >> "$dest"
+    cat "$src" >> "$dest"
+    printf "\n%s\n" "$marker" >> "$dest"
+    echo "  OK   copilot: $dest"
+}
+
+echo "Installing Document Filters skills (platform: $PLATFORM)"
+while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+    echo "[$skill]"
+    case "$PLATFORM" in
+        claude-code) install_claude_code "$skill" ;;
+        cursor)      install_cursor "$skill" ;;
+        copilot)     install_copilot "$skill" ;;
+        all)
+            install_claude_code "$skill"
+            install_cursor "$skill"
+            install_copilot "$skill"
+            ;;
+        *) echo "Unknown platform: $PLATFORM"; usage ;;
+    esac
+done < <(get_skills)
+
+echo "Done."

--- a/skills/process-documents-for-ai/skill.md
+++ b/skills/process-documents-for-ai/skill.md
@@ -1,0 +1,244 @@
+---
+name: process-documents-for-ai
+description: Extract and chunk text from documents for LLM ingestion using Document Filters
+---
+
+# Process Documents for AI Pipelines
+
+Hyland Document Filters runs entirely on-premise — no conversion servers, no data leaving your environment — and extracts clean text from 600+ file formats (Word, PDF, email archives, ZIP containers, and more) through a single API call. This skill shows how to extract and chunk document text for feeding into an LLM or vector store.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode. Evaluation mode inserts watermark strings directly into extracted text — do not use for production AI pipelines. Set `DF_LICENSE_KEY` to a valid key before extracting text that will be passed to an LLM or embedding model.
+
+## Extract Text and Split into Chunks
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def extract_chunks(filename, chunk_size=1000, overlap=100):
+    """
+    Extract text from a document and split into overlapping chunks.
+    Returns a list of dicts: {text, source, chunk_index}
+    """
+    if overlap >= chunk_size:
+        raise ValueError("overlap must be less than chunk_size")
+    with api.GetExtractor(filename) as doc:
+        if not doc.getSupportsText():
+            return []
+        doc.Open(IGR_BODY_AND_META, "PDF_TABLE_DETECTION=on;PDF_LAYOUT_DETECTION=on")
+        parts = []
+        while not doc.getEOF():
+            parts.append(doc.GetText(4096, stripControlCodes=True))
+        full_text = "".join(parts)
+
+    chunks = []
+    start = 0
+    idx = 0
+    while start < len(full_text):
+        end = min(start + chunk_size, len(full_text))
+        chunks.append({
+            "text": full_text[start:end],
+            "source": filename,
+            "chunk_index": idx,
+        })
+        step = chunk_size - overlap
+        start += step
+        idx += 1
+
+    return chunks
+
+# Usage
+for chunk in extract_chunks("report.pdf", chunk_size=500, overlap=50):
+    print(f"Chunk {chunk['chunk_index']}: {chunk['text'][:80]}...")
+    # Pass chunk['text'] to your embedding model or LLM
+```
+
+## Convert to LLM-optimized Markdown
+
+For documents with headings, tables, or structured lists, rendering to Markdown preserves that structure and provides richer context to the LLM than plain `GetText()` extraction, which flattens all formatting. Canvas-based markdown output uses `MARKDOWN_FLAVOR=GPT` for LLM-optimized formatting. This requires a valid `DF_LICENSE_KEY` — canvas devices are not available in evaluation mode.
+
+```python
+import io
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+def convert_to_llm_markdown(filename, out_path):
+    with api.GetExtractor(filename) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "PDF_TABLE_DETECTION=on;PDF_LAYOUT_DETECTION=on")
+        with api.MakeOutputCanvas(out_path, IGR_DEVICE_MARKDOWN, "MARKDOWN_FLAVOR=GPT") as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+
+def convert_to_llm_markdown_string(filename):
+    buf = io.BytesIO()
+    with api.GetExtractor(filename) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "PDF_TABLE_DETECTION=on;PDF_LAYOUT_DETECTION=on")
+        with api.MakeOutputCanvas(buf, IGR_DEVICE_MARKDOWN, "MARKDOWN_FLAVOR=GPT") as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+    return buf.getvalue().decode("utf-8")
+```
+
+## Processing Multiple Files
+
+```python
+import glob
+import os
+import sys
+
+def process_folder(folder, chunk_size=1000, overlap=100):
+    all_chunks = []
+    for path in glob.glob(f"{folder}/**/*", recursive=True):
+        if not os.path.isfile(path):
+            continue
+        try:
+            chunks = extract_chunks(path, chunk_size, overlap)
+            all_chunks.extend(chunks)
+        except Exception as e:
+            print(f"Skipping {path}: {e}", file=sys.stderr)
+    return all_chunks
+```
+
+## SubFiles (Archives and Email Folders)
+
+For compound formats such as `.zip`, `.pst`, and `.mbox`, iterate child documents via `SubFiles`. Each child must be opened individually before text can be extracted. Attachments can themselves be archives (e.g., a `.pst` message with an attached `.zip`), so the helper below recurses until it reaches leaf documents. The function returns a flat list of chunks — one entry per message or attachment — which maps directly to documents in a vector store. Each chunk carries the attachment name as `source`, enabling source citation in RAG responses.
+
+```python
+def _chunk_text(text, source, chunk_size, overlap):
+    """Split text into overlapping chunks. Returns list of {text, source, chunk_index}."""
+    chunks = []
+    start = 0
+    idx = 0
+    step = chunk_size - overlap
+    while start < len(text):
+        chunks.append({
+            "text": text[start:min(start + chunk_size, len(text))],
+            "source": source,
+            "chunk_index": idx,
+        })
+        start += step
+        idx += 1
+    return chunks
+
+def _extract_from_doc(doc, source_name, chunk_size, overlap, all_chunks):
+    """Recursively extract text from a document or container."""
+    if doc.getSupportsSubFiles():
+        # Containers (.zip, .pst, .mbox) do not need PDF options; open with empty options string.
+        doc.Open(IGR_BODY_AND_META, "")
+        for child in doc.SubFiles:
+            with child:
+                _extract_from_doc(child, child.getName(), chunk_size, overlap, all_chunks)
+    if doc.getSupportsText():
+        doc.Open(IGR_BODY_AND_META, "PDF_TABLE_DETECTION=on;PDF_LAYOUT_DETECTION=on")
+        parts = []
+        while not doc.getEOF():
+            parts.append(doc.GetText(4096, stripControlCodes=True))
+        all_chunks.extend(_chunk_text("".join(parts), source_name, chunk_size, overlap))
+
+def extract_with_subfiles(filename, chunk_size=1000, overlap=100):
+    all_chunks = []
+    with api.GetExtractor(filename) as doc:
+        _extract_from_doc(doc, filename, chunk_size, overlap, all_chunks)
+    return all_chunks
+```
+
+## Real-World Example: RAG Pipeline over a SharePoint Export
+
+Extract all Word and PDF files from a folder, chunk them, and load into a vector store for retrieval-augmented generation:
+
+```python
+import chromadb
+
+collection = chromadb.Client().create_collection("policies")
+chunks = process_folder("/exports/sharepoint", chunk_size=800, overlap=80)
+collection.add(
+    documents=[c["text"] for c in chunks],
+    metadatas=[{"source": c["source"], "chunk": c["chunk_index"]} for c in chunks],
+    ids=[f"{c['source']}::{c['chunk_index']}" for c in chunks],
+)
+# The collection is now queryable: collection.query(query_texts=["vacation policy"], n_results=5)
+```
+
+For email archives (`.pst`, `.mbox`), replace `process_folder` with `extract_with_subfiles` — it recurses through messages and attachments automatically, producing the same `{text, source, chunk_index}` shape.
+
+## Notes
+
+- **Prefer Markdown for structured documents:** When feeding an LLM and document structure (headings, tables, lists) matters, use `convert_to_llm_markdown()` (canvas-based, `MARKDOWN_FLAVOR=GPT`) instead of `extract_chunks()`. Plain text extraction loses all structure; Markdown preserves it. Requires a valid `DF_LICENSE_KEY`.
+- Use `chunk_size` and `overlap` to match your embedding model's context window
+- Canvas-based output (`IGR_DEVICE_MARKDOWN`, `IGR_DEVICE_HTML`, `IGR_DEVICE_IMAGE_PDF`, etc.) requires a valid `DF_LICENSE_KEY`. These devices are not available in evaluation mode.
+- **Unsupported formats:** When `getSupportsText()` returns `False` and `getSupportsSubFiles()` returns `False`, the format is not supported for text extraction. `extract_chunks()` returns an empty list in this case — check for it before passing to an LLM.
+- **Password-protected files:** `Open()` raises `IGRException` if the file requires a password and none is supplied. To provide a password programmatically, set `PasswordCallback` on the extractor before calling `Open()`:
+
+  ```python
+  with api.GetExtractor(filename) as doc:
+      doc.PasswordCallback = lambda doc_id: "secret"
+      doc.Open(IGR_BODY_AND_META, "")
+      ...
+  ```
+
+- **Missing or unreadable files:** `Open()` raises `IGRException` for files that do not exist, cannot be read, or are corrupt. Wrap extraction calls in `try/except IGRException` when processing untrusted or user-supplied paths.
+
+## Options
+
+### doc.Open() options string (semicolon-separated)
+
+| Option | Values | Description |
+|---|---|---|
+| `PDF_TABLE_DETECTION` | `on` / `off` | Detect table structure in PDFs; improves LLM context quality |
+| `PDF_LAYOUT_DETECTION` | `on` / `off` | Detect column/layout structure in PDFs |
+| `PDF_BOOKMARKS` | `true` / `false` | Include PDF bookmark/outline headings as text nodes — improves section-level context for chunking and retrieval |
+
+> Note: `true`/`false` are the canonical values; `on`/`off` and `1`/`0` are accepted synonyms.
+
+### MakeOutputCanvas() options string (semicolon-separated, canvas only)
+
+| Option | Values | Description |
+|---|---|---|
+| `MARKDOWN_FLAVOR` | `GPT` / `GFM` | LLM-optimized markdown (`GPT`) or GitHub-Flavored Markdown |
+| `MARKDOWN_HEADERS_STYLE` | `ATX` / `Setext` | Heading style in output markdown |
+| `MARKDOWN_SIMPLE_TABLE_STYLE` | `PIPE` / `GRID` / `HTML` / `PIPE_WITH_HTML` | Rendering style for simple tables (default: `PIPE`) |
+| `MARKDOWN_COMPLEX_TABLE_STYLE` | `PIPE` / `GRID` / `HTML` / `PIPE_WITH_HTML` | Rendering style for complex/merged-cell tables (default: `HTML`) |
+| `MARKDOWN_INCLUDE_HEADERS` | `on` / `off` | Include page headers in output (default: `off`) |
+| `MARKDOWN_INCLUDE_FOOTERS` | `on` / `off` | Include page footers in output (default: `off`) |
+| `MARKDOWN_INCLUDE_IMAGES` | `on` / `off` | Include embedded images in output (default: `off`) |
+| `MARKDOWN_INCLUDE_LOCATIONS` | `on` / `off` | Inject `<!-- LOC: page, (l,t,r,b) -->` before each paragraph — enables chunk-to-source traceability for RAG pipelines (default: `off`) |
+
+> Note: `on`/`off` are the canonical values; `true`/`false` and `1`/`0` are accepted synonyms.
+
+To parse LOC comments downstream and map each chunk back to its source page and bounding box:
+
+```python
+import re
+
+LOC_RE = re.compile(r'<!-- LOC: (\d+), \((-?\d+),(-?\d+),(-?\d+),(-?\d+)\) -->')
+
+def parse_loc_comments(markdown_text):
+    """
+    Return a list of (page, (left, top, right, bottom)) tuples
+    for each LOC comment found in the markdown output.
+    """
+    results = []
+    for m in LOC_RE.finditer(markdown_text):
+        page = int(m.group(1))
+        bbox = (int(m.group(2)), int(m.group(3)), int(m.group(4)), int(m.group(5)))
+        results.append((page, bbox))
+    return results
+```
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/process-email-archives/skill.md
+++ b/skills/process-email-archives/skill.md
@@ -1,0 +1,254 @@
+---
+name: process-email-archives
+description: Extract text and attachments from email archives (PST, MBOX, EML, MSG) using Document Filters
+---
+
+# Process Email Archives
+
+Hyland Document Filters lets AI engineers and data teams extract every email, attachment, and nested file from PST, MBOX, EML, and MSG archives using a single Python API — locally, with no cloud calls or Microsoft software required. It treats email archives as recursive containers, making them first-class sources for RAG pipelines, LLM ingestion, and eDiscovery workflows. Supporting 600+ formats including PST and OST (Outlook's proprietary archive formats normally requiring Microsoft software to open), all processing stays on-premises.
+
+Supported formats include: `.pst`, `.ost`, `.mbox`, `.eml`, `.msg`, `.emlx`, `.mbx`
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages). All email formats (PST, OST, MBOX, EML, MSG) require a valid license key — they are not available in evaluation mode.
+
+## Quick Start — In-Memory EML Demo
+
+The snippet below builds a minimal EML entirely in memory — ideal for first-run tests and conference booth demos (requires `DF_LICENSE_KEY`):
+
+```python
+import io, os
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+# Build a minimal EML in memory — no file needed
+msg = MIMEMultipart()
+msg['Subject'] = 'Hello from Document Filters'
+msg['From'] = 'demo@example.com'
+msg['To'] = 'you@example.com'
+msg.attach(MIMEText('This is a demo message for the conference booth.'))
+eml_bytes = msg.as_bytes()
+
+def extract_email(doc):
+    """Extract text and metadata from a single email/message subfile."""
+    text_parts = []
+    if doc.getSupportsText():
+        doc.Open(IGR_BODY_AND_META, "")
+        while not doc.getEOF():
+            text_parts.append(doc.GetText(4096, stripControlCodes=True))
+    return {
+        "file_type": doc.getFileType(IGR_FORMAT_LONG_NAME),
+        "text": "".join(text_parts),
+    }
+
+with api.GetExtractor(io.BytesIO(eml_bytes)) as doc:
+    result = extract_email(doc)
+    print(result['text'][:200])
+```
+
+> Note: All email formats require a valid `DF_LICENSE_KEY` — see the Setup section above.
+
+## Extract All Messages from an Archive
+
+For PST/MBOX archives (all email formats require a license key — see Setup), use the same `extract_email` helper defined above, then add a recursive walker:
+
+```python
+# import io, os and api initialization — already done in the Quick Start block above
+# extract_email() — already defined above
+
+def walk_archive(doc, results=None, depth=0):
+    """Recursively walk an email archive or container, extracting all messages."""
+    if results is None:
+        results = []
+
+    result = extract_email(doc)
+    if result["text"]:
+        results.append(result)
+
+    # Note: if getSupportsText() returned False above, doc.Open() was never called.
+    # _needHandle() will auto-open the doc with IGR_BODY_AND_META here so SubFiles
+    # can be iterated. This is intentional — container formats (ZIP, nested PST)
+    # need to be opened to enumerate their children even when they have no text body.
+    if doc.getSupportsSubFiles():
+        for subfile in doc.SubFiles:
+            with subfile:
+                walk_archive(subfile, results, depth + 1)
+
+    return results
+
+def process_email_archive(path):
+    with api.GetExtractor(path) as doc:
+        return walk_archive(doc)
+
+messages = process_email_archive("inbox.pst")
+print(f"Extracted {len(messages)} messages")
+```
+
+## Rich Extraction — Text, Subject, Sender, Attachments
+
+```python
+def parse_email_headers(text):
+    """
+    Extract common email headers from text produced by IGR_BODY_AND_META.
+    The header block appears at the top of the text stream as 'Key: Value' lines
+    followed by a blank line before the message body.
+    """
+    headers = {}
+    for line in text.splitlines():
+        if not line.strip():
+            break  # end of header block
+        if ": " in line:
+            key, _, value = line.partition(": ")
+            headers[key.strip().lower()] = value.strip()
+    return headers
+
+def extract_email_rich(doc, name=""):
+    """Extract message body, metadata headers, plus recurse into attachments."""
+    result = {
+        "name": name,
+        "file_type": doc.getFileType(IGR_FORMAT_LONG_NAME),
+        "text": "",
+        "metadata": {},   # subject, from, to, date — parsed from header block
+        "attachments": [],
+    }
+
+    if doc.getSupportsText():
+        doc.Open(IGR_BODY_AND_META, "")
+        parts = []
+        while not doc.getEOF():
+            parts.append(doc.GetText(4096, stripControlCodes=True))
+        result["text"] = "".join(parts)
+        # IGR_BODY_AND_META injects email headers (Subject, From, To, Date, etc.)
+        # at the top of the text stream before the message body.
+        result["metadata"] = parse_email_headers(result["text"])
+
+    # Recurse into subfiles (attachments, nested messages)
+    if doc.getSupportsSubFiles():
+        for subfile in doc.SubFiles:
+            with subfile:
+                child = extract_email_rich(subfile, name=subfile.getName())
+                result["attachments"].append(child)
+
+    return result
+
+def process_archive_rich(path):
+    with api.GetExtractor(path) as archive:
+        return extract_email_rich(archive, name=os.path.basename(path))
+```
+
+## Flatten for RAG Ingestion
+
+```python
+def flatten_for_rag(node, source_path="", records=None):
+    """
+    Flatten the recursive email tree into a list of RAG-ready records.
+    Each record has: source, text, depth indicator.
+    """
+    if records is None:
+        records = []
+
+    text = node.get("text", "").strip()
+    if text:
+        records.append({
+            "source": source_path or node["name"],
+            "name": node["name"],
+            "file_type": node["file_type"],
+            "text": text,
+            "metadata": node.get("metadata", {}),  # subject, from, to, date
+        })
+
+    for attachment in node.get("attachments", []):
+        child_path = f"{source_path or node['name']} / {attachment['name']}"
+        flatten_for_rag(attachment, child_path, records)
+
+    return records
+
+# Full pipeline: PST → flat records → ready for chunking + embedding
+archive = process_archive_rich("inbox.pst")
+records = flatten_for_rag(archive)
+print(f"{len(records)} extractable items (messages + attachments)")
+for r in records[:5]:
+    print(f"  [{r['file_type']}] {r['source']}: {r['text'][:60]}...")
+```
+
+## Convert Emails to Markdown
+
+For richer structure preservation, convert each message to Markdown. This builds on the initialized `api` from the section above:
+
+```python
+import io, os  # already imported at the top of this file; repeated here for standalone clarity
+# assumes api is already initialized (see above)
+def email_to_markdown(doc, include_locations=False):
+    """
+    Convert a message subfile to a Markdown string.
+
+    include_locations=True: adds <!-- LOC: page, (l,t,r,b) --> comments before
+    each paragraph when converting emails that embed PDF or Word attachments.
+    These location comments link extracted text back to its source position,
+    which is useful for AI citation and highlight-back features.
+    """
+    if not doc.getSupportsText():
+        return ""
+    opts = "MARKDOWN_FLAVOR=GPT;MARKDOWN_INCLUDE_METADATA=on;MARKDOWN_METADATA_FORMAT=YAML"
+    if include_locations:
+        opts += ";MARKDOWN_INCLUDE_LOCATIONS=on"
+    buf = io.BytesIO()
+    doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+    with api.MakeOutputCanvas(buf, IGR_DEVICE_MARKDOWN, opts) as canvas:
+        for page in doc.Pages:
+            with page:
+                canvas.RenderPage(page)
+    return buf.getvalue().decode("utf-8")
+```
+
+Use `email_to_markdown` in a recursive walk over the archive — the same pattern as `walk_archive` but producing Markdown strings instead of plain text:
+
+```python
+def archive_to_markdown_records(path, include_locations=False):
+    """Convert every text-bearing item in an archive to a Markdown record."""
+    results = []
+    with api.GetExtractor(path) as archive:
+        def _walk(doc, source):
+            md = email_to_markdown(doc, include_locations=include_locations)
+            if md:
+                results.append({"source": source, "markdown": md})
+            if doc.getSupportsSubFiles():
+                for subfile in doc.SubFiles:
+                    with subfile:
+                        child_source = f"{source} / {subfile.getName()}"
+                        _walk(subfile, child_source)
+        _walk(archive, os.path.basename(path))
+    return results
+
+md_records = archive_to_markdown_records("inbox.pst")
+# Each record: {"source": "inbox.pst / Message 001", "markdown": "---\nsubject: ...\n---\n..."}
+# Ready for text splitting and embedding.
+print(f"{len(md_records)} Markdown records produced")
+
+# For emails with embedded PDF or Word attachments, enable location comments:
+md_records_with_locs = archive_to_markdown_records("inbox.pst", include_locations=True)
+# Markdown will contain lines like:
+#   <!-- LOC: 1, (72,144,540,156) -->
+# before each paragraph, linking text back to its source position in the attachment.
+```
+
+## Notes
+
+- `walk_archive()` recurses into any container format, including ZIP files or nested PST/MBOX archives attached to messages — no extra steps are required.
+- `doc.getSupportsText()` returns `False` for binary attachments (images, executables) — these are skipped automatically
+- All email formats (PST, OST, MBOX, EML, MSG) require a valid license key — none are available in evaluation mode
+- For production pipelines, wrap the `with subfile:` block in `try/except IGRException` to skip corrupted or unsupported messages without aborting the full archive walk
+- For large PST archives (10k+ messages), process in batches to avoid memory pressure
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/redact-document/skill.md
+++ b/skills/redact-document/skill.md
@@ -1,0 +1,87 @@
+---
+name: redact-document
+description: Redact text matching a pattern from a document and render the result as PDF
+---
+
+# Redact Content from a Document
+
+Hyland Document Filters redacts sensitive content from 600+ file formats — PDFs, Word, Excel, email, and more — entirely on your own infrastructure, with no data sent to external services. It extracts word-level bounding boxes, strips matching text from the content stream, and overlays opaque black bars, producing a tamper-resistant redacted PDF.
+
+## Setup
+
+```bash
+pip install document-filters
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+## Python
+
+Redaction requires two passes per page. The first pass calls `page.Redact()` before `RenderPage()` to strip matched text from the PDF content stream, preventing recovery via copy-paste or PDF text extraction tools. The second pass draws opaque black rectangles over the same word positions to visually obscure the redacted region in rendered or rasterized output. Both passes are required for tamper-resistant redaction.
+
+> **Pattern scope:** Each pattern is matched against a single word token. Patterns that span whitespace between words (e.g. `r'John\s+Doe'`) will never match because a word object contains only one token's text. Use single-token patterns only; if you need to redact a multi-word phrase, match each token individually (e.g. `r'^John$'` and `r'^Doe$'`).
+
+```python
+import os
+import re
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def redact_document(input_path, output_path, patterns):
+    """
+    Redact words matching any of the given regex patterns.
+    patterns: list of regex strings matched against individual word tokens.
+    Multi-word span patterns (containing r'\s+') will not match — see note above.
+    Example patterns: [r'\b\d{3}-\d{2}-\d{4}\b', r'\bConfidential\b']
+    """
+    compiled = [re.compile(p, re.IGNORECASE) for p in patterns]
+
+    with api.GetExtractor(input_path) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "GRAPHIC_DPI=300")
+        if not doc.getSupportsText():
+            raise ValueError(f'{input_path} does not support word-level extraction; redaction is not possible')
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PDF, "") as canvas:
+            for page in doc.Pages:
+                with page:
+                    for i, word in enumerate(page.Words):
+                        for pattern in compiled:
+                            if pattern.search(word.Text):
+                                page.Redact(i, i)
+                                break
+                    canvas.RenderPage(page)
+                    # Post-render: draw opaque bars on top of the rendered page content (canvas draw calls overlay the rendered image)
+                    canvas.SetBrush(0x000000, IGR_BRUSH_SOLID)  # solid black fill
+                    canvas.SetPen(0, 0, IGR_PEN_NONE)
+                    for word in page.Words:
+                        for pattern in compiled:
+                            if pattern.search(word.Text):
+                                canvas.Rect(word.X, word.Y,
+                                            word.X + word.Width,
+                                            word.Y + word.Height)
+                                break
+
+redact_document(
+    "contract.pdf",
+    "contract_redacted.pdf",
+    patterns=[r'\b\d{3}-\d{2}-\d{4}\b',                        # SSN
+              r'\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b',     # credit card
+              r'[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}']  # email address
+)
+```
+
+## Notes
+
+- The first loop calls `page.Redact(wordIndex, wordIndex)` before `RenderPage()` to remove matched text from the PDF content stream. The second loop draws opaque rectangles over the same words as a visual black bar. Both are required: content stream redaction prevents text recovery via copy-paste; the rectangle ensures visual concealment in rasterized output.
+- `page.Words` returns word-level bounding boxes. Word and canvas coordinates are in the same page-geometry space (typically 1/100 mm for most formats). They are not affected by `GRAPHIC_DPI` — that option only controls rasterization quality for the PDF image stream, not coordinate values. Do not scale word coordinates by DPI before passing to `canvas.Rect`.
+- `canvas.SetBrush(0x000000, IGR_BRUSH_SOLID)` sets a solid black fill; change the color for colored redaction bars
+- Pass rendering options as a semicolon-separated string to `doc.Open()`, e.g. `GRAPHIC_DPI=300` for 300 DPI rasterization. `MakeOutputCanvas` options control output format metadata; pass them as the third argument, e.g. `api.MakeOutputCanvas(output_path, IGR_DEVICE_IMAGE_PDF, "PDF_TITLE=Redacted;PDF_AUTHOR=Compliance Team")`.
+- For password-protected files, supply a password callback: `doc.PasswordCallback = lambda doc_id: 'secret'` before calling `doc.Open()`.
+- Input must support word-level extraction; the example guards this with `doc.getSupportsText()` immediately after `Open()`. Documents without extractable text (e.g. image-only PDFs, some archive formats) will raise a `ValueError`.
+- This skill redacts the rendered PDF output. If you also need to redact text extracted for RAG (e.g., via `convert-to-markdown` or plain-text extraction), apply your regex patterns to the extracted text separately — the PDF redaction does not propagate to text extraction pipelines.
+- Eval mode limits output to the first few pages.
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/summarize-document/skill.md
+++ b/skills/summarize-document/skill.md
@@ -1,0 +1,107 @@
+---
+name: summarize-document
+description: Extract text from any document and produce a summary using an LLM
+---
+
+# Summarize a Document
+
+Hyland Document Filters extracts text from 600+ file formats — Word, PDF, Excel, PowerPoint, email, archives, and more — without conversion servers or cloud dependencies. This skill uses it to extract text from any supported file and pass it to an LLM for summarization.
+
+## Setup
+
+```bash
+pip install document-filters anthropic
+```
+
+Native runtime binaries (~60 MB) are downloaded automatically on first use. Binaries are cached in the package directory after the first download and do not re-download on subsequent runs. Set `DF_LICENSE_KEY` in your environment for full features — omitting it runs in evaluation mode (watermarked output, limited pages).
+
+## Step 1 — Extract the text
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")  # set DF_LICENSE_KEY env var; "" = eval mode
+
+def get_document_text_from_extractor(doc, max_chars=20000):
+    parts = []
+    total = 0
+    if doc.getSupportsText():
+        doc.Open(IGR_BODY_AND_META, "")
+        while not doc.getEOF() and total < max_chars:
+            chunk = doc.GetText(4096, stripControlCodes=True)
+            remaining = max_chars - total
+            parts.append(chunk[:remaining])
+            total += min(len(chunk), remaining)
+            if total >= max_chars:
+                break
+    if doc.getSupportsSubFiles():
+        for child in doc.SubFiles:
+            with child:
+                parts.append(get_document_text_from_extractor(child, max(0, max_chars - total)))
+    return "".join(parts)
+
+def get_document_text(filename, max_chars=20000):
+    with api.GetExtractor(filename) as doc:
+        return get_document_text_from_extractor(doc, max_chars)
+```
+
+## Step 2 — Summarize with an LLM
+
+Pass the extracted text to your preferred LLM. Example using the Anthropic SDK:
+
+```python
+import anthropic
+
+client = anthropic.Anthropic()  # uses ANTHROPIC_API_KEY env var
+
+def summarize(filename):
+    text = get_document_text(filename)
+    message = client.messages.create(
+        model="claude-sonnet-4-6",  # fast and cost-effective for summarization; swap for claude-opus-4-8 for higher accuracy on complex documents
+        max_tokens=1024,
+        messages=[{
+            "role": "user",
+            "content": f"Summarize this document in 3-5 bullet points:\n\n{text}"
+        }]
+    )
+    return message.content[0].text
+
+print(summarize("quarterly_report.pdf"))
+```
+
+## Alternative — Render to Markdown for richer LLM input
+
+For documents with headings, tables, or complex structure, rendering to Markdown preserves that structure and improves LLM summarization quality:
+
+```python
+def get_document_markdown(filename, output_path="output.md"):
+    with api.GetExtractor(filename) as doc:
+        doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on")  # improve table fidelity for PDFs; safe to pass for non-PDF formats
+        canvas_options = "MARKDOWN_FLAVOR=GPT"
+        with api.MakeOutputCanvas(output_path, IGR_DEVICE_MARKDOWN, canvas_options) as canvas:
+            for page in doc.Pages:
+                with page:
+                    canvas.RenderPage(page)
+    with open(output_path, "r", encoding="utf-8") as f:
+        return f.read()
+```
+
+Pass the result of `get_document_markdown(filename)` to the LLM instead of `get_document_text(filename)`.
+
+**Note:** `output_path` is a required intermediate file written to disk and is not automatically deleted. Either pass a path inside a temporary directory or delete it after use. To avoid residual files, use `tempfile.NamedTemporaryFile(suffix=".md", delete=False)` and remove the file explicitly once its contents have been read.
+
+## Notes
+
+- `max_chars=20000` is a safe default; increase for longer documents if your LLM's context allows
+- Eval mode limits extraction to the first few pages
+- Document Filters supports 600+ formats: Word, PDF, Excel, PowerPoint, email, archives, and more
+- For PDFs with tables, pass `"PDF_LAYOUT_DETECTION=on;PDF_TABLE_DETECTION=on"` as the options string to `doc.Open()` to improve table extraction fidelity; `PDF_TABLE_DETECTION` requires `PDF_LAYOUT_DETECTION=on` to be set first
+- To cite page numbers in summaries, modify the `canvas_options` string in `get_document_markdown` to include `MARKDOWN_INCLUDE_LOCATIONS=on` (e.g., `canvas_options = "MARKDOWN_FLAVOR=GPT;MARKDOWN_INCLUDE_LOCATIONS=on"`) — DF injects `<!-- LOC: page, (l,t,r,b) -->` before each paragraph, letting the LLM reference exact source locations in its output
+- The Markdown canvas path (`get_document_markdown`) requires a valid `DF_LICENSE_KEY` — canvas devices are not available in evaluation mode. Plain text extraction via `get_document_text` works in eval mode (first few pages only)
+- For container formats (ZIP, PST, MBOX, EML), `get_document_markdown` returns empty output — these formats have no pages, so the canvas renders nothing. Use `get_document_text` for archives and email, or call `doc.getSupportsSubFiles()` to detect container formats and select the appropriate extraction path
+
+## Reference
+
+https://hyland.github.io/DocumentFilters-Docs/latest/

--- a/skills/use-document-filters-api/skill.md
+++ b/skills/use-document-filters-api/skill.md
@@ -1,0 +1,249 @@
+---
+name: use-document-filters-api
+description: Initialize and use the Hyland Document Filters SDK in Python, C#, Java, or C++
+---
+
+# Using the Document Filters API
+
+Document Filters turns any file — Word, PDF, email, archive, CAD drawing, and 600+ more formats — into clean text or structured output ready for LLMs, RAG pipelines, and document AI, running entirely on your own infrastructure with no conversion servers or cloud dependencies.
+
+## Setup (Python)
+
+Install the package:
+```bash
+pip install document-filters
+```
+
+Initialize the API:
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+# The Python SDK does NOT auto-read any env var — pass the key explicitly.
+# Empty string = evaluation mode (limited pages, watermarked output).
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+```
+
+Set `DF_LICENSE_KEY` in your environment or `.env` file. The `dll_path` third argument defaults to `None` (auto-detect) and can be omitted. When using the pip package, binaries are bundled. When running the GitHub samples directly, they are downloaded on first use.
+
+## Core Pattern
+
+All Document Filters operations follow the same pattern: get an extractor for a file, open it in the desired mode, then process pages or text.
+
+```python
+import os
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+with api.GetExtractor("input.docx") as doc:
+    # Check what the file supports
+    print(doc.getFileType(IGR_FORMAT_LONG_NAME))   # e.g. "Microsoft Word 2007"
+    print(doc.getSupportsText())                   # True if text extraction works
+    print(doc.getSupportsSubFiles())               # True for archives, emails, etc.
+
+    # Open for text extraction
+    doc.Open(IGR_BODY_AND_META, "")
+
+    # Open for rendering (pages to images, PDF, HTML, etc.)
+    doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+```
+
+### Text Extraction
+
+```python
+with api.GetExtractor("input.docx") as doc:
+    doc.Open(IGR_BODY_AND_META, "")
+    if not doc.getSupportsText():
+        # File does not support text extraction (e.g. image-only PDF, CAD drawing)
+        return
+    text = []
+    while not doc.getEOF():
+        chunk = doc.GetText(4096, stripControlCodes=True)
+        text.append(chunk)
+    full_text = "".join(text)
+```
+
+### Page Rendering
+
+```python
+with api.GetExtractor("input.docx") as doc:
+    doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+    with api.MakeOutputCanvas("output.pdf", IGR_DEVICE_IMAGE_PDF, "") as canvas:
+        for page in doc.Pages:
+            with page:
+                canvas.RenderPage(page)
+```
+
+### Subfile Traversal (archives, emails)
+
+```python
+with api.GetExtractor("input.zip") as doc:
+    if doc.getSupportsSubFiles():
+        for child in doc.SubFiles:
+            with child:
+                child.Open(IGR_BODY_AND_META, "")
+                if not child.getSupportsText():
+                    continue
+                while not child.getEOF():
+                    chunk = child.GetText(4096, stripControlCodes=True)
+                    # process chunk
+```
+
+## Putting It Together
+
+The snippet below processes a folder of mixed-format files — PDFs, Word documents, emails, and archives — and converts each one to Markdown for RAG ingestion. It handles subfile traversal for archives and emails, skips image-only files gracefully, and uses `MARKDOWN_FLAVOR=GPT` for cleaner LLM input.
+
+```python
+import os
+from pathlib import Path
+from DocumentFilters import *
+
+api = DocumentFilters()
+api.Initialize(os.environ.get("DF_LICENSE_KEY", ""), ".")
+
+OPEN_OPTS = "PDF_LAYOUT_DETECTION=ON;PDF_TABLE_DETECTION=ON"
+MD_OPTS   = "MARKDOWN_FLAVOR=GPT;MARKDOWN_INCLUDE_IMAGES=false;MARKDOWN_INCLUDE_LOCATIONS=true"
+
+def extract_to_markdown(extractor, canvas):
+    """Render one extractor (file or subfile) to the shared canvas."""
+    extractor.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, OPEN_OPTS)
+    if not extractor.getSupportsText():
+        return  # image-only file — skip silently
+    for page in extractor.Pages:
+        with page:
+            canvas.RenderPage(page)
+
+def process_file(path: str, output_dir: str):
+    out_path = Path(output_dir) / (Path(path).stem + ".md")
+    with api.GetExtractor(path) as doc:
+        with api.MakeOutputCanvas(str(out_path), IGR_DEVICE_MARKDOWN, MD_OPTS) as canvas:
+            if doc.getSupportsSubFiles():
+                # Archives, ZIP, EML, MSG — recurse into attachments
+                for child in doc.SubFiles:
+                    with child:
+                        extract_to_markdown(child, canvas)
+            else:
+                extract_to_markdown(doc, canvas)
+    return out_path
+
+input_folder  = "docs/"
+output_folder = "output_md/"
+Path(output_folder).mkdir(exist_ok=True)
+
+for file in Path(input_folder).iterdir():
+    if file.is_file():
+        try:
+            result = process_file(str(file), output_folder)
+            print(f"OK  {file.name} -> {result.name}")
+        except IGRException as e:
+            print(f"ERR {file.name}: {e}")
+```
+
+Key points: `getSupportsSubFiles()` is checked before iterating children so plain files never trigger subfile logic. `getSupportsText()` guards against image-only PDFs and CAD drawings. A single `MakeOutputCanvas` per input file keeps all pages and attachments in one output document.
+
+## Open Modes
+
+| Flag | Meaning |
+|---|---|
+| `IGR_BODY_AND_META` | Extract text and metadata |
+| `IGR_FORMAT_IMAGE` | Enable page rendering |
+
+## Output Devices (for rendering)
+
+| Constant | Output | Notes |
+|---|---|---|
+| `IGR_DEVICE_IMAGE_PDF` | PDF | |
+| `IGR_DEVICE_HTML` | HD HTML5 | Requires a full license; not available in evaluation mode. |
+| `IGR_DEVICE_IMAGE_PNG` | PNG (one file per page) | |
+| `IGR_DEVICE_IMAGE_TIF` | TIFF | |
+| `IGR_DEVICE_MARKDOWN` | Markdown | |
+| `IGR_DEVICE_XML` | XML | |
+| `IGR_DEVICE_JSON` | JSON | |
+
+### Markdown Canvas Options
+
+When using `IGR_DEVICE_MARKDOWN`, pass a semicolon-separated options string to `MakeOutputCanvas`:
+
+| Option | Values | Description |
+|---|---|---|
+| `MARKDOWN_FLAVOR` | `GPT`, `GFM` | `GPT` is LLM-optimized (cleaner structure, reduced noise); recommended for AI pipelines |
+| `MARKDOWN_HEADERS_STYLE` | `ATX`, `SETEXT` | |
+| `MARKDOWN_SIMPLE_TABLE_STYLE` | `PIPE`, `GRID`, `HTML`, `PIPE_WITH_HTML` | |
+| `MARKDOWN_COMPLEX_TABLE_STYLE` | `PIPE`, `GRID`, `HTML`, `PIPE_WITH_HTML` | |
+| `MARKDOWN_INCLUDE_HEADERS` | `on`, `off` | |
+| `MARKDOWN_INCLUDE_FOOTERS` | `on`, `off` | |
+| `MARKDOWN_INCLUDE_IMAGES` | `on`, `off` | |
+| `MARKDOWN_INCLUDE_LOCATIONS` | `on`, `off` | Injects `<!-- LOC: page, (l,t,r,b) -->` before each paragraph — links text back to its source page and bounding box; useful for citation and grounding in RAG pipelines |
+
+Use `MARKDOWN_FLAVOR=GPT` when feeding Document Filters output into an LLM or AI agent pipeline.
+
+> Boolean option values accept `true`/`false`, `on`/`off`, and `1`/`0` interchangeably (case-insensitive).
+
+Example:
+```python
+opts = "MARKDOWN_FLAVOR=GPT;MARKDOWN_SIMPLE_TABLE_STYLE=PIPE;MARKDOWN_INCLUDE_IMAGES=false"
+with api.MakeOutputCanvas("output.md", IGR_DEVICE_MARKDOWN, opts) as canvas:
+    for page in doc.Pages:
+        with page:
+            canvas.RenderPage(page)
+```
+
+## Doc-Open Options
+
+Pass a semicolon-separated options string as the second argument to `doc.Open()` to control document processing. For PDFs, enabling layout and table detection significantly improves table extraction fidelity:
+
+```python
+options = "PDF_LAYOUT_DETECTION=ON;PDF_TABLE_DETECTION=ON"
+doc.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, options)
+```
+
+| Option | Values | Effect |
+|---|---|---|
+| `PDF_LAYOUT_DETECTION` | `ON`, `OFF` | Improves column and layout detection in PDFs |
+| `PDF_TABLE_DETECTION` | `ON`, `OFF` | Improves table structure detection in PDFs |
+| `PDF_BOOKMARKS` | `true`, `false` | Includes PDF bookmark headings in extracted text and rendered output. Must be passed to `doc.Open()`, not `MakeOutputCanvas()`. |
+
+> Option values are case-insensitive; `ON`/`OFF`, `true`/`false`, and `1`/`0` are all accepted synonyms.
+
+## Document Comparison
+
+Document comparison requires a full license (not available in evaluation mode).
+
+```python
+with api.GetExtractor("original.docx") as doc1:
+    with api.GetExtractor("revised.docx") as doc2:
+        doc1.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+        doc2.Open(IGR_BODY_AND_META | IGR_FORMAT_IMAGE, "")
+
+        settings = CompareSettings()
+        settings.CompareType = IGR_COMPARE_DOCUMENTS_COMPARE_WORDS
+
+        results = doc1.Compare(doc2, compareSettings=settings)
+        while results.MoveNext():
+            diff = results.Current
+            for hit in diff.Details:
+                print(diff.Type, hit.Text)
+```
+
+`diff.Type` indicates the kind of change (insertion, deletion, move, etc.). `diff.Details` is a list of `CompareResultDifferenceDetail` objects; each has `.Text`, `.Bounds`, and `.PageIndex`. Use `diff.GetText()` to join all detail texts into a single string.
+
+Additional comparison flags can be OR-combined with `IGR_COMPARE_DOCUMENTS_FLAGS_NO_CASE` to suppress specific content from the diff: `IGR_COMPARE_DOCUMENTS_FLAGS_NO_HEADERS`, `NO_FOOTERS`, `NO_TEXTBOXES`, `NO_FIELDS`, `NO_FOOTNOTES`, `NO_WHITESPACE`, `NO_PUNCTUATION`, and others. See the `compare-documents` skill for the full flag table.
+
+## Other Languages
+
+- **C#**: Install `Hyland.DocumentFilters` NuGet package. `var df = new DocumentFilters(); df.Initialize("", ".");` — the C# SDK reads `DOCFILTERS_LICENSE_KEY` automatically when an empty string is passed (note: different env var name from Python's `DF_LICENSE_KEY`).
+- **Java**: Add the DocumentFilters JAR. API is `DocumentFilters api = new DocumentFilters(); api.Initialize(licenseKey, ".");`
+- **C++**: Link against `ISYS11df`. Include `DocumentFiltersObjects.h`.
+
+## Notes
+
+- **`GetExtractor()` defers errors to `Open()`**: `api.GetExtractor()` does not raise for missing or unreadable files. Errors (file not found, unsupported format, permission denied) surface when `doc.Open()` is called. Always wrap `Open()` — not just `GetExtractor()` — in `try/except IGRException`.
+- **Python vs C# env var names differ**: The Python SDK reads `DF_LICENSE_KEY`; the C# SDK reads `DOCFILTERS_LICENSE_KEY`. Setting the wrong variable leaves the SDK in evaluation mode with no error.
+- **Evaluation mode injects watermarks into extracted content**: When initialized with an empty string license key, Document Filters inserts watermark text into extracted text, Markdown output, and HTML output. This makes evaluation-mode output unsuitable for production AI pipelines — watermark strings will appear verbatim in LLM inputs, embeddings, and search indexes. Set `DF_LICENSE_KEY` to a valid key for any pipeline that processes extracted content programmatically.
+
+## Reference
+
+Full API docs: https://hyland.github.io/DocumentFilters-Docs/latest/


### PR DESCRIPTION
Adds a skills/ folder containing structured prompt files that teach AI coding agents (Claude Code, Cursor, GitHub Copilot) and AI pipeline agents how to use the Hyland Document Filters SDK across 13 use cases:

Skills:
- use-document-filters-api: SDK initialization and core patterns
- extract-text: plain text extraction from 600+ formats
- convert-to-pdf: document-to-PDF rendering with bookmark options
- convert-to-html: HD HTML5 rendering with inline image support
- convert-to-png: per-page PNG rendering
- convert-to-markdown: structured Markdown with full options table including PDF layout/table detection and MARKDOWN_INCLUDE_LOCATIONS
- process-documents-for-ai: chunking and LLM ingestion pipeline
- summarize-document: text extraction + LLM summarization
- extract-document-metadata: file type, page count, and properties
- redact-document: regex-based redaction to PDF
- compare-documents: word-level document diffing with full flags table
- process-email-archives: PST/MBOX/EML/MSG recursive extraction with RAG flattening and in-memory EML conference demo
- extract-document-structure: Markdown and JSON structural extraction with location data, word bounding boxes, and citation-aware RAG

Also includes:
- install.sh (bash/macOS/Linux/WSL) and install.ps1 (Windows) for automated idempotent installation into Claude Code, Cursor, and GitHub Copilot
- document-filters-api.instructions.md for Copilot auto-load