### PR TITLE
Remove String allocation in GetText

### DIFF
--- a/bindings/dotnet/src/Hyland.DocumentFilters/Extractor.cs
+++ b/bindings/dotnet/src/Hyland.DocumentFilters/Extractor.cs
@@ -653,7 +653,8 @@ namespace Hyland.DocumentFilters
 
             Check(ISYS11df.IGR_Get_Text(NeedHandle(), buffer, ref retval, ref ecb), ecb);
             _eof = retval == 0;
-            return buffer.ToString().Substring(0, retval);
+            buffer.Length = retval;
+            return buffer.ToString();
         }
 
         /// <summary>


### PR DESCRIPTION
This simplifies the code and allows the final string to be created directly from the correctly sized StringBuilder, rather than first converting the full buffer to a string and then extracting the returned text.