### PR TITLE
Add optimized Extractor.GetText to allow passing in Memory

### DIFF
--- a/bindings/dotnet/src/Hyland.DocumentFilters/DocumentFiltersAPI.cs
+++ b/bindings/dotnet/src/Hyland.DocumentFilters/DocumentFiltersAPI.cs
@@ -1571,6 +1571,13 @@ namespace Hyland.DocumentFilters
         [DllImport("ISYS11df", EntryPoint = "IGR_Get_Text")]
         public static extern int IGR_Get_Text(int handle, [MarshalAs(UnmanagedType.LPWStr)] System.Text.StringBuilder buffer, ref int bufferSize, ref Error_Control_Block error);
 
+        // Return Type: IGR_RETURN_CODE->LONG->int
+        ///handle: LONG->int
+        ///buffer: LPWSTR->WCHAR*
+        ///bufferSize: LONG*
+        ///error: Error_Control_Block*
+        [DllImport("ISYS11df", EntryPoint = "IGR_Get_Text")]
+        public static extern int IGR_Get_Text_Ptr(int handle, IntPtr buffer, ref int bufferSize, ref Error_Control_Block error);
 
         // Return Type: IGR_RETURN_CODE->LONG->int
         ///handle: LONG->int

--- a/bindings/dotnet/src/Hyland.DocumentFilters/Extractor.cs
+++ b/bindings/dotnet/src/Hyland.DocumentFilters/Extractor.cs
@@ -640,6 +640,24 @@ namespace Hyland.DocumentFilters
             return _eof;
         }
 
+#if NETSTANDARD
+        /// <summary>
+        /// The GetText method extracts the next portion of text content from the document.
+        /// </summary>
+        /// <param name="memory">The memory buffer to store the UTF-16 characters.</param>
+        /// <returns>The number of characters read.</returns>
+        public unsafe int GetText(Memory<char> memory)
+        {
+            using (var handle = memory.Pin())
+            {
+                var ecb = new Error_Control_Block();
+                var retval = memory.Length;
+                IGRException.Check(ISYS11df.IGR_Get_Text_Ptr(NeedHandle(), (IntPtr)handle.Pointer, ref retval, ref ecb), ecb);
+                return retval;
+            }
+        }
+#endif
+
         /// <summary>
         /// The GetText method extracts the next portion of text content from the document.
         /// </summary>
@@ -822,6 +840,14 @@ namespace Hyland.DocumentFilters
             return new SubFile(this, NeedHandle(), id, null, 0, 0, ISYS11df.IGR_Extract_Image_Stream);
         }
 
+        /// <summary>
+        /// The ToStream method extracts the binary content of the sub-document to a stream.
+        /// </summary>
+        /// <returns>A stream containing the binary content of the sub-document.</returns>
+        public System.IO.Stream ToStream()
+        {
+            return new StreamBridge(NeedStream());
+        }
 
         /// <summary>
         /// The CopyTo method extracts the binary content of the sub-document to a file.

--- a/bindings/dotnet/src/Hyland.DocumentFilters/Hyland.DocumentFilters.csproj
+++ b/bindings/dotnet/src/Hyland.DocumentFilters/Hyland.DocumentFilters.csproj
@@ -44,8 +44,11 @@
 		<Folder Include="Properties\" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-	  <PackageReference Include="System.Drawing.Common">
-	    <Version>4.7.3</Version>
-	  </PackageReference>
+		<PackageReference Include="System.Drawing.Common">
+			<Version>4.7.3</Version>
+		</PackageReference>
+		<PackageReference Include="System.Memory">
+			<Version>4.6.3</Version>
+		</PackageReference>
 	</ItemGroup>
 </Project>


### PR DESCRIPTION
This gives callers more explicit control over the Memory that is used when extracting text. Also added are a method for accessing the Stream of a SubFile to prevent the need for copying unnecessarily (again to allow a caller to have more explicit control over allocations).